### PR TITLE
fix: remove useless context from configurable activities input

### DIFF
--- a/pkg/workflowengine/activities/email.go
+++ b/pkg/workflowengine/activities/email.go
@@ -29,7 +29,6 @@ func (SendMailActivity) Name() string {
 // It retrieves the SMTP host, port, and sender email from environment variables.
 // If the environment variables are not set, it uses default values.
 func (a *SendMailActivity) Configure(
-	_ context.Context,
 	input *workflowengine.ActivityInput,
 ) error {
 	input.Config["smtp_host"] = utils.GetEnvironmentVariable("SMTP_HOST", "smtp.apps.forkbomb.eu")

--- a/pkg/workflowengine/activities/email_test.go
+++ b/pkg/workflowengine/activities/email_test.go
@@ -48,7 +48,7 @@ func TestSendMailActivity_Configure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupEnv()
-			err := activity.Configure(t.Context(), input)
+			err := activity.Configure(input)
 
 			require.NoError(t, err)
 			require.Equal(t, "smtp.example.com", input.Config["smtp_host"])

--- a/pkg/workflowengine/activities/stepci.go
+++ b/pkg/workflowengine/activities/stepci.go
@@ -33,7 +33,6 @@ func (StepCIWorkflowActivity) Name() string {
 
 // Configure injects the parsed template and token into the payload
 func (a *StepCIWorkflowActivity) Configure(
-	_ context.Context,
 	input *workflowengine.ActivityInput,
 ) error {
 	yamlString := input.Config["template"]

--- a/pkg/workflowengine/activities/stepci_test.go
+++ b/pkg/workflowengine/activities/stepci_test.go
@@ -67,7 +67,7 @@ func TestStepCIlActivity_Configure(t *testing.T) {
 				Payload: tc.payload,
 			}
 
-			err := activity.Configure(t.Context(), input)
+			err := activity.Configure(input)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/workflowengine/activity.go
+++ b/pkg/workflowengine/activity.go
@@ -35,7 +35,7 @@ type ExecutableActivity interface {
 
 // ConfigurableActivity is an interface that defines the structure of a configurable activity.
 type ConfigurableActivity interface {
-	Configure(ctx context.Context, input *ActivityInput) error
+	Configure(input *ActivityInput) error
 }
 
 // Fail is a utility function that appends an error message to the activity result's errors.

--- a/pkg/workflowengine/workflows/openidnet.go
+++ b/pkg/workflowengine/workflows/openidnet.go
@@ -96,7 +96,7 @@ func (w *OpenIDNetWorkflow) Workflow(
 		},
 	}
 	var stepCIResult workflowengine.ActivityResult
-	err := stepCIWorkflowActivity.Configure(context.Background(), &stepCIInput)
+	err := stepCIWorkflowActivity.Configure(&stepCIInput)
 	if err != nil {
 		logger.Error(" StepCI configure failed", "error", err)
 		return workflowengine.WorkflowResult{}, err
@@ -138,7 +138,7 @@ func (w *OpenIDNetWorkflow) Workflow(
 	`, u.String(), u.String()),
 		},
 	}
-	err = emailActivity.Configure(context.Background(), &emailInput)
+	err = emailActivity.Configure(&emailInput)
 	if err != nil {
 		logger.Error("Email activity configure failed", "error", err)
 		return workflowengine.WorkflowResult{}, err


### PR DESCRIPTION
This was  an old leftover from when the configure function used to be considered an activity.