### PR TITLE
feat: create data directory before dev and docker targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(WEBENV):
 $(DATA):
 	mkdir -p $(DATA)
 
-dev: $(WEBENV) tools devtools submodules $(BIN) $(DATA)## 🚀 run in watch mode
+dev: $(WEBENV) tools devtools submodules $(BIN) $(DATA) ## 🚀 run in watch mode
 	DEBUG=1 $(GOTOOL) hivemind -T Procfile.dev
 
 test: ## 🧪 run tests with coverage

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ version: ## ℹ️ Display version information
 $(WEBENV):
 	cp $(WEBAPP)/.env.example $(WEBAPP)/.env
 
-dev: $(WEBENV) tools devtools submodules ## 🚀 run in watch mode
+$(DATA):
+	mkdir -p $(DATA)
+
+dev: $(WEBENV) tools devtools submodules $(BIN) $(DATA)## 🚀 run in watch mode
 	DEBUG=1 $(GOTOOL) hivemind -T Procfile.dev
 
 test: ## 🧪 run tests with coverage
@@ -126,7 +129,7 @@ $(BINARY_NAME)-ui: $(UI_SRC)
 	cd $(WEBAPP) && bun i && bun run bin; \
 	kill $$PID;
 
-docker: submodules ## 🐳 run docker with all the infrastructure services
+docker: $(DATA) submodules ## 🐳 run docker with all the infrastructure services
 	docker compose build --build-arg PUBLIC_POCKETBASE_URL="http://localhost:8090"
 	docker compose up
 


### PR DESCRIPTION
Ensure the $(DATA) directory is created before running dev and docker
commands by adding a dedicated rule in the Makefile. This prevents errors
caused by missing directories and improves the reliability of the build
and development workflow.