### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/up_version.yml
+++ b/.github/workflows/up_version.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: 🚦 Update version
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ForkbombEu/credimi/security/code-scanning/3](https://github.com/ForkbombEu/credimi/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow performs operations like reading repository contents, committing changes, and pushing updates, we will grant the minimal required permissions. Specifically:
- `contents: write` is needed to commit and push changes to the repository.
- All other permissions will be omitted to restrict access to only what is necessary.

The `permissions` block will be added at the root level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
