### PR TITLE
chore: remove module name from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-module github.com/forkbombeu/credimi
 
 go 1.24.2
 


### PR DESCRIPTION
The module name is not needed in go.mod files since go 1.11.
