### PR TITLE
chore: add wait-for-it script to Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Forkbomb BV
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-API: go tool gow run main.go serve
+API: ./scripts/wait-for-it.sh -s -t 0 localhost:7233 && go tool gow run main.go serve
 UI: ./scripts/wait-for-it.sh -s -t 0 localhost:8090 && cd webapp && bun i && bun dev
 BE: temporal server start-dev --db-filename pb_data/temporal.db


### PR DESCRIPTION
Adds wait-for-it script to ensure services are ready before starting.
