### PR TITLE
feat: add vscode launch config and optional env to stepci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ pb.env
 /didimo
 /credimi
 didimo-ui
-/.vscode
 /fixtures/test_pb_data/auxiliary.db
 /pkg/OpenID4VP/stepci/node_modules
 dist/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Program",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "serve"
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {},
+            "envFile": "${workspaceFolder}/.env"
+        }
+    ]
+}

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,6 +11,7 @@ SPDX-PackageDownloadLocation = "https://github.com/ForkbombEu/credimi"
 path = [
     ".env.example",
     ".vscode/settings.json",
+    ".vscode/launch.json",
     "config_templates/**/*",
     "docs/**/*",
     "fixtures/test_pb_data/types.d.ts",

--- a/pkg/workflowengine/activities/stepci.go
+++ b/pkg/workflowengine/activities/stepci.go
@@ -118,15 +118,6 @@ func (a *StepCIWorkflowActivity) Execute(
 			fmt.Sprintf("%s: 'yaml", errCode.Description),
 		)
 	}
-	yamlEnv, ok := input.Payload["env"].(string)
-	if !ok {
-		errCode := errorcodes.Codes[errorcodes.MissingOrInvalidPayload]
-		return result, a.NewActivityError(
-			errCode.Code,
-			fmt.Sprintf("%s: 'env'", errCode.Description),
-		)
-	}
-	
 
 	filtered := make(map[string]string)
 	for k, v := range input.Config {
@@ -144,11 +135,15 @@ func (a *StepCIWorkflowActivity) Execute(
 		)
 	}
 
-
 	binDir := utils.GetEnvironmentVariable("BIN", ".bin")
 	binName := "stepci-captured-runner"
 	binPath := fmt.Sprintf("%s/%s", binDir, binName)
-	args := []string{yamlContent, "-s", string(jsonBytes), "--env", yamlEnv}
+	args := []string{yamlContent, "-s", string(jsonBytes)}
+
+	yamlEnv, _ := input.Payload["env"].(string)
+	if yamlEnv != "" {
+		args = append(args, "--env", yamlEnv)
+	}
 
 	cmd := exec.CommandContext(ctx, binPath, args...)
 


### PR DESCRIPTION
Adds a vscode launch configuration for debugging.
Also makes the env variable optional for stepci.
