### PR TITLE
feat: add GitHub Actions workflow for link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 The lychee maintainers
+#
+# SPDX-License-Identifier: MIT
+
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
[empty]

- Creates a new workflow named "Links" to check links periodically
- Runs every day at 6 PM UTC
- Uses lychee-action to check broken links
- Generates a report if issues are found
- Creates an issue from the report if there are broken links