### PR TITLE
fix: when importing a new credential issuer, to test its well-know exists, do a complete request

### DIFF
--- a/pkg/internal/apis/workflows.go
+++ b/pkg/internal/apis/workflows.go
@@ -287,7 +287,7 @@ func checkEndpointExists(ctx context.Context, urlToCheck string) error {
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "HEAD", parsedURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", parsedURL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
- **fix: when importing a new credential issuer, to test its well-know exists, do a complete request**

close: #520 
