### PR TITLE
chore: update credimi-extra dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/forkbombeu/credimi-extra v0.0.0-20260109110935-d9a29adf3f94
+	github.com/forkbombeu/credimi-extra v0.0.0-20260114110938-de9365d6d20d
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sprout/sprout v1.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/forkbombeu/credimi-extra v0.0.0-20260108165247-9ab11ebb28ec h1:qCUQo/
 github.com/forkbombeu/credimi-extra v0.0.0-20260108165247-9ab11ebb28ec/go.mod h1:a/FVETkgFsGelWqP3qi2IWZz370C+DbSAIpnoLNBEyU=
 github.com/forkbombeu/credimi-extra v0.0.0-20260109110935-d9a29adf3f94 h1:AK0BU/sdIj6VweEoGNZVQAtkqeXKtTEytvafWq7Ywq8=
 github.com/forkbombeu/credimi-extra v0.0.0-20260109110935-d9a29adf3f94/go.mod h1:31A5rHv7SJ1cDmnP0hy+gApNw9aIZjOGBNBeH3pNsQw=
+github.com/forkbombeu/credimi-extra v0.0.0-20260114110938-de9365d6d20d h1:kdYjbZXkMHMWAtY936tzyGsjGoyupbsd0QAqgZnHajM=
+github.com/forkbombeu/credimi-extra v0.0.0-20260114110938-de9365d6d20d/go.mod h1:31A5rHv7SJ1cDmnP0hy+gApNw9aIZjOGBNBeH3pNsQw=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
Update credimi-extra to commit: de9365d6d20d62919a26ace5d5bfae974ff1b8e2