### PR TITLE
chore: update credimi-extra dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/forkbombeu/credimi-extra v0.0.0-20260122121438-b571b6813264
+	github.com/forkbombeu/credimi-extra v0.0.0-20260128115844-1d35f8007c3c
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sprout/sprout v1.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ github.com/forkbombeu/credimi-extra v0.0.0-20260114150907-4e7b69255c9a h1:nUoLOM
 github.com/forkbombeu/credimi-extra v0.0.0-20260114150907-4e7b69255c9a/go.mod h1:31A5rHv7SJ1cDmnP0hy+gApNw9aIZjOGBNBeH3pNsQw=
 github.com/forkbombeu/credimi-extra v0.0.0-20260122121438-b571b6813264 h1:Vh/82gA0K6ejVJBonI2YryIo7lSivyqhJjZpjo8JI2M=
 github.com/forkbombeu/credimi-extra v0.0.0-20260122121438-b571b6813264/go.mod h1:31A5rHv7SJ1cDmnP0hy+gApNw9aIZjOGBNBeH3pNsQw=
+github.com/forkbombeu/credimi-extra v0.0.0-20260128115844-1d35f8007c3c h1:m8BfejI5Oh+UIQciYUweTvMWiKDSUV/3fkbI93w48ww=
+github.com/forkbombeu/credimi-extra v0.0.0-20260128115844-1d35f8007c3c/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
Update credimi-extra to commit: 1d35f8007c3c16b1979cd14c5a4371cecc9efa9e