### PR TITLE
chore: update credimi-extra dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/forkbombeu/credimi-extra v0.0.0-20260128100701-4f74b06458b2
+	github.com/forkbombeu/credimi-extra v0.0.0-20260129075522-a2be9451c9a7
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sprout/sprout v1.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ github.com/forkbombeu/credimi-extra v0.0.0-20260127155450-8d7796a848bc h1:GsoTN/
 github.com/forkbombeu/credimi-extra v0.0.0-20260127155450-8d7796a848bc/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
 github.com/forkbombeu/credimi-extra v0.0.0-20260128100701-4f74b06458b2 h1:hvNWsATSZBGXUqLnO6vznNI1kL9mwQ4IwC8uYajmSjg=
 github.com/forkbombeu/credimi-extra v0.0.0-20260128100701-4f74b06458b2/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
+github.com/forkbombeu/credimi-extra v0.0.0-20260129075522-a2be9451c9a7 h1:DYbys3jJJjDdvfHvhaNtRGL3PyP+OQpU8ewUTV0YAdo=
+github.com/forkbombeu/credimi-extra v0.0.0-20260129075522-a2be9451c9a7/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
Update credimi-extra to commit: a2be9451c9a7ef8a332f7ef33404f369aebf1502