### PR TITLE
chore: update credimi-extra dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/forkbombeu/credimi-extra v0.0.0-20260202073528-2bd0bd4b5432
+	github.com/forkbombeu/credimi-extra v0.0.0-20260202095335-759e503540ce
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sprout/sprout v1.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,8 @@ github.com/forkbombeu/credimi-extra v0.0.0-20260128100701-4f74b06458b2 h1:hvNWsA
 github.com/forkbombeu/credimi-extra v0.0.0-20260128100701-4f74b06458b2/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
 github.com/forkbombeu/credimi-extra v0.0.0-20260202073528-2bd0bd4b5432 h1:3HjyT27FjsaNFSa0lj0w+kIR989NpgKiLlRif/iF0TQ=
 github.com/forkbombeu/credimi-extra v0.0.0-20260202073528-2bd0bd4b5432/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
+github.com/forkbombeu/credimi-extra v0.0.0-20260202095335-759e503540ce h1:g4wWb2tH2747MRiVJ2/bXXgJCpeDavFVMwwzI5zcT8U=
+github.com/forkbombeu/credimi-extra v0.0.0-20260202095335-759e503540ce/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
Update credimi-extra to commit: 759e503540cec0f54a2a67e7123defdca97bc487