### PR TITLE
chore: update credimi-extra dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/forkbombeu/credimi-extra v0.0.0-20260202101017-47d42a28532b
+	github.com/forkbombeu/credimi-extra v0.0.0-20260203141518-3c14a6c715d6
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sprout/sprout v1.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -649,6 +649,8 @@ github.com/forkbombeu/avdctl v0.0.0-20251117141832-94a8ef48fc9b h1:Hcga7FlNFKa+d
 github.com/forkbombeu/avdctl v0.0.0-20251117141832-94a8ef48fc9b/go.mod h1:2PyuTviG6/ts65ybsWFKYqE9wiRWwm9minyEaClSbZI=
 github.com/forkbombeu/credimi-extra v0.0.0-20260202101017-47d42a28532b h1:g95iQIvhkdYoh30x1GaCArYuN+Ls69eLjgIyuCKNS/A=
 github.com/forkbombeu/credimi-extra v0.0.0-20260202101017-47d42a28532b/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
+github.com/forkbombeu/credimi-extra v0.0.0-20260203141518-3c14a6c715d6 h1:yqDTBtDrIKFrDEv/hEGaf0852v0waC2namLiiCBO+Jo=
+github.com/forkbombeu/credimi-extra v0.0.0-20260203141518-3c14a6c715d6/go.mod h1:7bpdgJc6TjxKu0I7LiUQ2SWssnjfW3HzwZ3HnfowkNE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
Update credimi-extra to commit: 3c14a6c715d6c45f69595998e98531a74e4313d1