### PR TITLE
chore: update credimi-extra dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/forkbombeu/credimi-extra v0.0.0-20260203165731-2e6b6d0109f2
+	github.com/forkbombeu/credimi-extra v1.0.1
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sprout/sprout v1.0.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/forkbombeu/avdctl v0.0.0-20260203155454-da07200f16a6 h1:LgTRaAypGChhxWbRntALSC3TCPkpfzooS7dpkg5QnXI=
 github.com/forkbombeu/avdctl v0.0.0-20260203155454-da07200f16a6/go.mod h1:bCgZk+Q15y/YB39jGnZhwChGej7YYsX7Kgexg/GPMWA=
-github.com/forkbombeu/credimi-extra v0.0.0-20260203165731-2e6b6d0109f2 h1:X4LrdZTDOEEwMWID9AVJthEL/syKZsdDmCtV1itBU1I=
-github.com/forkbombeu/credimi-extra v0.0.0-20260203165731-2e6b6d0109f2/go.mod h1:w8t1N6ufWIepLfZYP87MHYZ+99f/q+B3SNdD9rlygLY=
+github.com/forkbombeu/credimi-extra v1.0.1 h1:2gnZgcnwKYRUKD1nTLu30I2woNCcB/N9jr54l9MKcIA=
+github.com/forkbombeu/credimi-extra v1.0.1/go.mod h1:w8t1N6ufWIepLfZYP87MHYZ+99f/q+B3SNdD9rlygLY=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=


### PR DESCRIPTION
Update credimi-extra to commit: db0b14fe559ab87104f4559265600fd5ea1bd3ec