### PR TITLE
fix(auth): turnstile registration also via rest

### DIFF
--- a/pkg/internal/apis/turnstile.go
+++ b/pkg/internal/apis/turnstile.go
@@ -30,39 +30,60 @@ type turnstileVerifyResponse struct {
 // HookTurnstileVerification validates Cloudflare Turnstile tokens on user registration.
 // It reads the token from the X-Turnstile-Token HTTP header and verifies it with Cloudflare.
 func HookTurnstileVerification(app *pocketbase.PocketBase) {
+	app.OnRecordAuthWithOAuth2Request("users").BindFunc(
+		func(e *core.RecordAuthWithOAuth2RequestEvent) error {
+			if !e.IsNewRecord {
+				return e.Next()
+			}
+
+			if err := requireTurnstile(e.RequestEvent); err != nil {
+				return err
+			}
+			return e.Next()
+		},
+	)
+
 	app.OnRecordCreateRequest("users").BindFunc(func(e *core.RecordRequestEvent) error {
 		if isOAuth2RecordCreateRequest(e) {
 			return e.Next()
 		}
 
-		token := e.Request.Header.Get("X-Turnstile-Token")
-		if token == "" {
-			return apis.NewBadRequestError("captcha verification failed", nil)
-		}
-
-		secret := utils.GetEnvironmentVariable("TURNSTILE_SECRET_KEY")
-		if secret == "" {
-			log.Printf("[turnstile] TURNSTILE_SECRET_KEY is not set, skipping verification")
-			return e.Next()
-		}
-
-		result, err := verifyTurnstileToken(token, secret)
-		if err != nil {
-			log.Printf("[turnstile] verification request failed: %v", err)
-			return apis.NewBadRequestError("captcha verification failed", nil)
-		}
-
-		if !result.Success {
-			log.Printf(
-				"[turnstile] verification failed: codes=%v hostname=%s",
-				result.ErrorCodes,
-				result.Hostname,
-			)
-			return apis.NewBadRequestError("captcha verification failed", nil)
+		if err := requireTurnstile(e.RequestEvent); err != nil {
+			return err
 		}
 
 		return e.Next()
 	})
+}
+
+func requireTurnstile(e *core.RequestEvent) error {
+	token := e.Request.Header.Get("X-Turnstile-Token")
+	if token == "" {
+		return apis.NewBadRequestError("captcha verification failed", nil)
+	}
+
+	secret := utils.GetEnvironmentVariable("TURNSTILE_SECRET_KEY")
+	if secret == "" {
+		log.Printf("[turnstile] TURNSTILE_SECRET_KEY is not set, skipping verification")
+		return nil
+	}
+
+	result, err := verifyTurnstileToken(token, secret)
+	if err != nil {
+		log.Printf("[turnstile] verification request failed: %v", err)
+		return apis.NewBadRequestError("captcha verification failed", nil)
+	}
+
+	if !result.Success {
+		log.Printf(
+			"[turnstile] verification failed: codes=%v hostname=%s",
+			result.ErrorCodes,
+			result.Hostname,
+		)
+		return apis.NewBadRequestError("captcha verification failed", nil)
+	}
+
+	return nil
 }
 
 func isOAuth2RecordCreateRequest(e *core.RecordRequestEvent) bool {

--- a/pkg/internal/apis/turnstile_test.go
+++ b/pkg/internal/apis/turnstile_test.go
@@ -47,6 +47,58 @@ func TestHookTurnstileVerification(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, called)
 	})
+
+	t.Run("requires captcha for OAuth2 registration", func(t *testing.T) {
+		app := pocketbase.New()
+		HookTurnstileVerification(app)
+
+		event := newOAuth2AuthRequestEvent(t, app)
+		event.IsNewRecord = true
+		err := app.OnRecordAuthWithOAuth2Request("users").
+			Trigger(event, func(e *core.RecordAuthWithOAuth2RequestEvent) error {
+				return nil
+			})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Captcha verification failed")
+	})
+
+	t.Run("allows OAuth2 login without captcha", func(t *testing.T) {
+		app := pocketbase.New()
+		HookTurnstileVerification(app)
+
+		called := false
+		event := newOAuth2AuthRequestEvent(t, app)
+		event.IsNewRecord = false
+		err := app.OnRecordAuthWithOAuth2Request("users").
+			Trigger(event, func(e *core.RecordAuthWithOAuth2RequestEvent) error {
+				called = true
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+
+	t.Run("accepts OAuth2 registration with captcha when secret is not configured", func(t *testing.T) {
+		t.Setenv("TURNSTILE_SECRET_KEY", "")
+
+		app := pocketbase.New()
+		HookTurnstileVerification(app)
+
+		called := false
+		event := newOAuth2AuthRequestEvent(t, app)
+		event.IsNewRecord = true
+		event.Request.Header.Set("X-Turnstile-Token", "test-token")
+		err := app.OnRecordAuthWithOAuth2Request("users").
+			Trigger(event, func(e *core.RecordAuthWithOAuth2RequestEvent) error {
+				called = true
+				return nil
+			})
+
+		require.NoError(t, err)
+		require.True(t, called)
+	})
 }
 
 func TestIsOAuth2RecordCreateRequest(t *testing.T) {
@@ -91,6 +143,32 @@ func newUserCreateRequestEvent(
 	event := &core.RecordRequestEvent{
 		RequestEvent: requestEvent,
 		Record:       core.NewRecord(users),
+	}
+	event.Collection = users
+
+	return event
+}
+
+func newOAuth2AuthRequestEvent(
+	t testing.TB,
+	app core.App,
+) *core.RecordAuthWithOAuth2RequestEvent {
+	t.Helper()
+
+	users := core.NewAuthCollection("users")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/collections/users/auth-with-oauth2", nil)
+	rec := httptest.NewRecorder()
+	requestEvent := &core.RequestEvent{
+		App: app,
+		Event: router.Event{
+			Request:  req,
+			Response: rec,
+		},
+	}
+
+	event := &core.RecordAuthWithOAuth2RequestEvent{
+		RequestEvent: requestEvent,
 	}
 	event.Collection = users
 

--- a/webapp/src/modules/auth/oauth/oauth.svelte
+++ b/webapp/src/modules/auth/oauth/oauth.svelte
@@ -38,6 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	let captchaError = $state('');
 	let turnstileContainer = $state<HTMLDivElement>();
 	let turnstileWidgetId = $state('');
+	let turnstileScriptLoaded = $state(false);
 
 	const authMethods = pb
 		.collection('users')
@@ -81,6 +82,27 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			})
 		);
 
+	function renderTurnstile() {
+		if (!requireCaptcha || !turnstileContainer || !window.turnstile || turnstileWidgetId) {
+			return;
+		}
+
+		turnstileWidgetId = window.turnstile.render(turnstileContainer, {
+			sitekey: PUBLIC_TURNSTILE_SITE_KEY,
+			callback: (token: string) => {
+				captchaToken = token;
+				captchaError = '';
+			},
+			theme: 'auto'
+		});
+	}
+
+	$effect(() => {
+		if (turnstileScriptLoaded && turnstileContainer) {
+			renderTurnstile();
+		}
+	});
+
 	onMount(() => {
 		if (!requireCaptcha) {
 			return;
@@ -90,27 +112,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			'script[src^="https://challenges.cloudflare.com/turnstile/v0/api.js"]'
 		);
 
-		const renderTurnstile = () => {
-			if (!turnstileContainer || !window.turnstile) {
-				return;
-			}
-			turnstileWidgetId = window.turnstile.render(turnstileContainer, {
-				sitekey: PUBLIC_TURNSTILE_SITE_KEY,
-				callback: (token: string) => {
-					captchaToken = token;
-					captchaError = '';
-				},
-				theme: 'auto'
-			});
+		const markTurnstileReady = () => {
+			turnstileScriptLoaded = true;
+			renderTurnstile();
 		};
 
 		if (window.turnstile) {
-			renderTurnstile();
+			markTurnstileReady();
 			return;
 		}
 
 		if (existingScript) {
-			existingScript.addEventListener('load', renderTurnstile, { once: true });
+			existingScript.addEventListener('load', markTurnstileReady, { once: true });
 			return;
 		}
 
@@ -118,7 +131,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
 		script.async = true;
 		script.defer = true;
-		script.onload = renderTurnstile;
+		script.onload = markTurnstileReady;
 		document.head.appendChild(script);
 	});
 </script>

--- a/webapp/src/modules/auth/oauth/oauth.svelte
+++ b/webapp/src/modules/auth/oauth/oauth.svelte
@@ -8,7 +8,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import type { ClientResponseError } from 'pocketbase';
 
 	import { PUBLIC_POCKETBASE_URL } from '$env/static/public';
+	import { PUBLIC_TURNSTILE_SITE_KEY } from '$env/static/public';
 	import { nanoid } from 'nanoid';
+	import { onMount } from 'svelte';
 
 	import type { Data, UsersRecord } from '@/pocketbase/types';
 
@@ -23,14 +25,19 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 	type Props = {
 		hideOr?: boolean;
+		requireCaptcha?: boolean;
 	};
 
-	const { hideOr = false }: Props = $props();
+	const { hideOr = false, requireCaptcha = false }: Props = $props();
 
 	//
 
 	let error = $state<ClientResponseError>();
 	let loading = $state(false);
+	let captchaToken = $state('');
+	let captchaError = $state('');
+	let turnstileContainer = $state<HTMLDivElement>();
+	let turnstileWidgetId = $state('');
 
 	const authMethods = pb
 		.collection('users')
@@ -41,26 +48,90 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					displayName: provider.displayName,
 					image: `${PUBLIC_POCKETBASE_URL}/_/images/oauth2/${provider.name}.svg`, // TODO - This won't work with `oidc2` for example
 					initializer: async () => {
+						if (requireCaptcha && !captchaToken) {
+							captchaError = m.Please_complete_the_captcha();
+							return;
+						}
+						captchaError = '';
 						loading = true;
 						try {
 							const createData: Data<UsersRecord> = { name: nanoid(5) };
 							const authData = await pb.collection('users').authWithOAuth2({
 								provider: provider.name,
-								createData
+								createData,
+								headers: requireCaptcha
+									? { 'X-Turnstile-Token': captchaToken }
+									: undefined
 							});
 							$currentUser = authData.record;
 							goto('/my');
 						} catch (e) {
 							error = e as ClientResponseError;
+							if (requireCaptcha) {
+								captchaToken = '';
+								captchaError = m.Please_complete_the_captcha();
+							}
+							if (requireCaptcha && turnstileWidgetId && window.turnstile) {
+								window.turnstile.reset(turnstileWidgetId);
+							}
 						}
 						loading = false;
 					}
 				};
 			})
 		);
+
+	onMount(() => {
+		if (!requireCaptcha) {
+			return;
+		}
+
+		const existingScript = document.querySelector<HTMLScriptElement>(
+			'script[src^="https://challenges.cloudflare.com/turnstile/v0/api.js"]'
+		);
+
+		const renderTurnstile = () => {
+			if (!turnstileContainer || !window.turnstile) {
+				return;
+			}
+			turnstileWidgetId = window.turnstile.render(turnstileContainer, {
+				sitekey: PUBLIC_TURNSTILE_SITE_KEY,
+				callback: (token: string) => {
+					captchaToken = token;
+					captchaError = '';
+				},
+				theme: 'auto'
+			});
+		};
+
+		if (window.turnstile) {
+			renderTurnstile();
+			return;
+		}
+
+		if (existingScript) {
+			existingScript.addEventListener('load', renderTurnstile, { once: true });
+			return;
+		}
+
+		const script = document.createElement('script');
+		script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+		script.async = true;
+		script.defer = true;
+		script.onload = renderTurnstile;
+		document.head.appendChild(script);
+	});
 </script>
 
 {#await authMethods then methods}
+	{#if requireCaptcha && methods.length > 0}
+		<div bind:this={turnstileContainer} class="mb-4 flex justify-center"></div>
+	{/if}
+
+	{#if requireCaptcha && captchaError}
+		<p class="mb-4 text-sm text-red-600 dark:text-red-400">{captchaError}</p>
+	{/if}
+
 	{#each methods as method (method.displayName)}
 		<Button class="w-full" variant="outline" onclick={method.initializer}>
 			<figure class="size-6 rounded-sm bg-white p-0.5">

--- a/webapp/src/routes/(nru)/register/+page.svelte
+++ b/webapp/src/routes/(nru)/register/+page.svelte
@@ -124,7 +124,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <T tag="h4">{m.Create_an_account()}</T>
 
 {#if $featureFlags.OAUTH}
-	<Oauth></Oauth>
+	<Oauth requireCaptcha></Oauth>
 {/if}
 
 <Form {form} hideRequiredIndicator>


### PR DESCRIPTION
reason:
Block automated user creation through direct registration and
new OAuth accounts while keeping existing login flows unchanged.

prompt:
Enforce Turnstile for registration only
