### PR TITLE
fix(openid): show logs by conformance metadata

### DIFF
--- a/webapp/src/lib/wallet-test-pages/openidnet.test.ts
+++ b/webapp/src/lib/wallet-test-pages/openidnet.test.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import { getOpenIDConformanceWorkflowLogsProps, isOpenIDConformanceStandard } from './openidnet';
+
+describe('OpenID conformance workflow logs', () => {
+	it.each([
+		['openid4vci_issuer', 'start-openid4vci-issuer-log-update'],
+		['openid4vp_verifier', 'start-openid4vp-verifier-log-update'],
+		['openid4vci_wallet', 'start-openidnet-check-log-update', '-log'],
+		['openid4vp_wallet', 'start-openidnet-check-log-update', '-log']
+	] as const)('selects the established adapter for %s', (standard, startSignal, suffix) => {
+		const props = getOpenIDConformanceWorkflowLogsProps('workflow-1', 'tenant', standard);
+
+		expect(props).toMatchObject({
+			workflowId: 'workflow-1',
+			namespace: 'tenant',
+			subscriptionSuffix: 'openidnet-logs',
+			startSignal
+		});
+		expect(props.workflowSignalSuffix).toBe(suffix);
+	});
+
+	it('recognizes only OpenID conformance standards with a log adapter', () => {
+		expect(isOpenIDConformanceStandard('openid4vp_verifier')).toBe(true);
+		expect(isOpenIDConformanceStandard('openid4vp_wallet')).toBe(true);
+		expect(isOpenIDConformanceStandard('ewc')).toBe(false);
+		expect(isOpenIDConformanceStandard(undefined)).toBe(false);
+	});
+});

--- a/webapp/src/lib/wallet-test-pages/openidnet.ts
+++ b/webapp/src/lib/wallet-test-pages/openidnet.ts
@@ -7,6 +7,44 @@ import { z } from 'zod/v3';
 
 //
 
+export type OpenIDConformanceStandard =
+	| 'openid4vci_issuer'
+	| 'openid4vp_verifier'
+	| 'openid4vci_wallet'
+	| 'openid4vp_wallet';
+
+const openIDConformanceStandards = new Set<OpenIDConformanceStandard>([
+	'openid4vci_issuer',
+	'openid4vp_verifier',
+	'openid4vci_wallet',
+	'openid4vp_wallet'
+]);
+
+export function isOpenIDConformanceStandard(
+	standard: string | undefined
+): standard is OpenIDConformanceStandard {
+	return (
+		standard !== undefined &&
+		openIDConformanceStandards.has(standard as OpenIDConformanceStandard)
+	);
+}
+
+export function getOpenIDConformanceWorkflowLogsProps(
+	workflowId: string | undefined,
+	namespace: string | undefined,
+	standard: OpenIDConformanceStandard
+): WorkflowLogsProps {
+	switch (standard) {
+		case 'openid4vci_issuer':
+			return getOpenID4VCIIssuerWorkflowLogsProps(workflowId, namespace);
+		case 'openid4vp_verifier':
+			return getOpenID4VPVerifierWorkflowLogsProps(workflowId, namespace);
+		case 'openid4vci_wallet':
+		case 'openid4vp_wallet':
+			return getOpenIDNetWorkflowLogsProps(workflowId, namespace);
+	}
+}
+
 export function getOpenIDNetWorkflowLogsProps(
 	workflowId?: string,
 	namespace?: string

--- a/webapp/src/routes/my/tests/runs/[workflow_id]/[run_id]/+page.svelte
+++ b/webapp/src/routes/my/tests/runs/[workflow_id]/[run_id]/+page.svelte
@@ -13,6 +13,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import { runWithLoading } from '$lib/layout/global-loading.svelte';
 	import { TemporalI18nProvider } from '$lib/temporal';
 	import { WorkflowQrPoller } from '$lib/workflows';
+	import { isOpenIDConformanceStandard } from '$lib/wallet-test-pages/openidnet';
 	import { onMount } from 'svelte';
 
 	import Alert from '@/components/ui-custom/alert.svelte';
@@ -107,20 +108,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	/* UI */
 
 	const testNameChunks = $derived(memo?.test.split('+') ?? []);
-	const isDedicatedOpenID4VCIIssuerWorkflow = $derived(
-		memo?.standard === 'openid4vci_issuer' &&
-			execution.name ===
-				'OID4VCI Issuer conformance check on https://www.certification.openid.net'
-	);
-	const isDedicatedOpenID4VPVerifierWorkflow = $derived(
-		memo?.standard === 'openid4vp_verifier' &&
-			execution.name ===
-				'OID4VP Verifier conformance check on https://www.certification.openid.net'
-	);
-	const shouldShowOpenIDNetTop = $derived(
-		memo?.standard !== 'openid4vci_issuer' && memo?.standard !== 'openid4vp_verifier'
-			? true
-			: isDedicatedOpenID4VCIIssuerWorkflow || isDedicatedOpenID4VPVerifierWorkflow
+	const openIDConformanceStandard = $derived(
+		memo?.author === 'openid_conformance_suite' && isOpenIDConformanceStandard(memo.standard)
+			? memo.standard
+			: undefined
 	);
 
 	const failureMessage = $derived(
@@ -239,12 +230,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	{:else}
 		<div class="bg-temporal padding-x space-y-8 pt-4">
 			{#if memo.author == 'openid_conformance_suite'}
-				{#if shouldShowOpenIDNetTop}
+				{#if openIDConformanceStandard}
 					<OpenidnetTop
 						{workflowId}
 						namespace={organization.canonified_name}
-						isIssuerWorkflow={isDedicatedOpenID4VCIIssuerWorkflow}
-						isVerifierWorkflow={isDedicatedOpenID4VPVerifierWorkflow}
+						standard={openIDConformanceStandard}
 					/>
 				{/if}
 			{:else if memo.author == 'eudiw'}

--- a/webapp/src/routes/my/tests/runs/[workflow_id]/[run_id]/_partials/openidnet-top.svelte
+++ b/webapp/src/routes/my/tests/runs/[workflow_id]/[run_id]/_partials/openidnet-top.svelte
@@ -6,9 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <script lang="ts">
 	import {
-		getOpenID4VCIIssuerWorkflowLogsProps,
-		getOpenID4VPVerifierWorkflowLogsProps,
-		getOpenIDNetWorkflowLogsProps
+		getOpenIDConformanceWorkflowLogsProps,
+		type OpenIDConformanceStandard
 	} from '$lib/wallet-test-pages/openidnet';
 	import WorkflowLogs from '$lib/workflows/workflow-logs.svelte';
 
@@ -20,26 +19,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	type Props = {
 		workflowId: string;
 		namespace: string;
-		isIssuerWorkflow?: boolean;
-		isVerifierWorkflow?: boolean;
+		standard: OpenIDConformanceStandard;
 	};
 
-	let {
-		workflowId,
-		namespace,
-		isIssuerWorkflow = false,
-		isVerifierWorkflow = false
-	}: Props = $props();
+	let { workflowId, namespace, standard }: Props = $props();
 
-	const workflowLogsProps = $derived.by(() => {
-		if (isIssuerWorkflow) {
-			return getOpenID4VCIIssuerWorkflowLogsProps(workflowId, namespace);
-		}
-		if (isVerifierWorkflow) {
-			return getOpenID4VPVerifierWorkflowLogsProps(workflowId, namespace);
-		}
-		return getOpenIDNetWorkflowLogsProps(workflowId, namespace);
-	});
+	const workflowLogsProps = $derived(
+		getOpenIDConformanceWorkflowLogsProps(workflowId, namespace, standard)
+	);
 </script>
 
 <Container>


### PR DESCRIPTION
reason:
Avoid coupling log visibility to Temporal workflow names while retaining child log adapters.

prompt:
Unify the OpenID log UI without changing child workflows.