### PR TITLE
fix(webapp): localize pocketbase errors via exact i18n keys

### DIFF
--- a/docs/superpowers/plans/2026-07-21-pocketbase-error-i18n-exact-match.md
+++ b/docs/superpowers/plans/2026-07-21-pocketbase-error-i18n-exact-match.md
@@ -1,0 +1,233 @@
+# PocketBase Error i18n Exact Match Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded PocketBase validation-code mapper with exact-key lookup against Paraglide `m`, using backend `validation_*` codes as message keys.
+
+**Architecture:** Add `localizePocketBaseErrorCode` in `webapp/src/modules/utils/errors.ts`. It looks up `code` on an optional message catalog (default `m`); if the value is a function that returns a string when called with no args, use that; otherwise return the backend fallback. Rename the wallet i18n key to match the Go code. Wire collection forms to the shared helper.
+
+**Tech Stack:** TypeScript, Paraglide (`m`), Vitest, PocketBase `ClientResponseError` field `{ code, message }`.
+
+**Design spec:** `docs/superpowers/specs/2026-07-21-pocketbase-error-i18n-exact-match-design.md`
+
+## Global Constraints
+
+- Exact string match only — no strip/capitalize transforms.
+- Backend `validation_*` codes are canonical; rename i18n, not Go.
+- Missing key → backend `message` fallback.
+- Do not add i18n for other custom codes in this pass.
+- Do not commit unless the user explicitly asks.
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `webapp/src/modules/utils/errors.ts` | `localizePocketBaseErrorCode` |
+| `webapp/src/modules/utils/errors.test.ts` | Unit tests for the helper |
+| `webapp/messages/{en,it,de,fr,da,pt-BR,es-es}.json` | Rename wallet validation message key |
+| `webapp/src/modules/collections-components/form/collectionFormSetup.ts` | Use shared helper; remove hardcoded branch |
+
+---
+
+### Task 1: Helper + unit tests (TDD)
+
+**Files:**
+- Modify: `webapp/src/modules/utils/errors.ts`
+- Modify: `webapp/src/modules/utils/errors.test.ts`
+
+**Interfaces:**
+- Produces: `localizePocketBaseErrorCode(code: string | undefined, fallback: string, catalog?: Record<string, unknown>): string`
+- `catalog` defaults to `m as unknown as Record<string, unknown>` so tests can inject stubs without mocking the whole i18n module.
+
+- [x] **Step 1: Write failing tests**
+
+Append to `errors.test.ts`:
+
+```ts
+import { localizePocketBaseErrorCode } from './errors';
+
+describe('localizePocketBaseErrorCode', () => {
+	const catalog = {
+		validation_wallet_action_market_link_requires_install_app: () => 'Localized wallet error',
+		validation_not_a_function: 'oops',
+		validation_throws: () => {
+			throw new Error('needs inputs');
+		},
+		validation_non_string: () => 42
+	} as Record<string, unknown>;
+
+	it('returns localized string when code matches a message function', () => {
+		expect(
+			localizePocketBaseErrorCode(
+				'validation_wallet_action_market_link_requires_install_app',
+				'fallback',
+				catalog
+			)
+		).toBe('Localized wallet error');
+	});
+
+	it('returns fallback for unknown codes', () => {
+		expect(localizePocketBaseErrorCode('validation_unknown', 'fallback', catalog)).toBe(
+			'fallback'
+		);
+	});
+
+	it('returns fallback when code is undefined', () => {
+		expect(localizePocketBaseErrorCode(undefined, 'fallback', catalog)).toBe('fallback');
+	});
+
+	it('returns fallback when catalog value is not a function', () => {
+		expect(
+			localizePocketBaseErrorCode('validation_not_a_function', 'fallback', catalog)
+		).toBe('fallback');
+	});
+
+	it('returns fallback when message function throws', () => {
+		expect(localizePocketBaseErrorCode('validation_throws', 'fallback', catalog)).toBe(
+			'fallback'
+		);
+	});
+
+	it('returns fallback when message function returns a non-string', () => {
+		expect(localizePocketBaseErrorCode('validation_non_string', 'fallback', catalog)).toBe(
+			'fallback'
+		);
+	});
+});
+```
+
+- [x] **Step 2: Run tests — expect fail**
+
+```sh
+cd webapp && bun run test:unit -- --run src/modules/utils/errors.test.ts
+```
+
+Expected: FAIL — `localizePocketBaseErrorCode` is not exported.
+
+- [x] **Step 3: Implement helper**
+
+In `errors.ts`:
+
+```ts
+import { m } from '@/i18n';
+
+export function localizePocketBaseErrorCode(
+	code: string | undefined,
+	fallback: string,
+	catalog: Record<string, unknown> = m as unknown as Record<string, unknown>
+): string {
+	if (!code) return fallback;
+
+	const candidate = catalog[code];
+	if (typeof candidate !== 'function') return fallback;
+
+	try {
+		const localized = (candidate as () => unknown)();
+		return typeof localized === 'string' ? localized : fallback;
+	} catch {
+		return fallback;
+	}
+}
+```
+
+Keep existing `getExceptionMessage` / `exceptionToError` unchanged.
+
+- [x] **Step 4: Run tests — expect pass**
+
+```sh
+cd webapp && bun run test:unit -- --run src/modules/utils/errors.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Rename i18n key in all locale files
+
+**Files:**
+- Modify: `webapp/messages/en.json`
+- Modify: `webapp/messages/it.json`
+- Modify: `webapp/messages/de.json`
+- Modify: `webapp/messages/fr.json`
+- Modify: `webapp/messages/da.json`
+- Modify: `webapp/messages/pt-BR.json`
+- Modify: `webapp/messages/es-es.json`
+
+**Interfaces:**
+- Produces: message key `validation_wallet_action_market_link_requires_install_app` (exact backend code)
+
+- [x] **Step 1: Rename key in every locale**
+
+Replace the JSON key only (keep each locale’s string value):
+
+- from: `"Wallet_action_market_link_requires_install_app"`
+- to: `"validation_wallet_action_market_link_requires_install_app"`
+
+- [x] **Step 2: Verify no old key remains**
+
+```sh
+rg 'Wallet_action_market_link_requires_install_app' webapp/messages webapp/src
+```
+
+Expected: no matches (except possibly this plan/spec docs).
+
+---
+
+### Task 3: Wire collection form to shared helper
+
+**Files:**
+- Modify: `webapp/src/modules/collections-components/form/collectionFormSetup.ts`
+
+**Interfaces:**
+- Consumes: `localizePocketBaseErrorCode` from `@/utils/errors`
+
+- [x] **Step 1: Update imports**
+
+- Remove `m` import if it becomes unused after this change (it is still used for success toasts — keep it).
+- Add: `import { getExceptionMessage, localizePocketBaseErrorCode } from '@/utils/errors';`
+- Remove the separate `getExceptionMessage` import path if duplicated; keep a single import from `@/utils/errors`.
+
+Current imports use `getExceptionMessage` from `@/utils/errors` — extend that import.
+
+- [x] **Step 2: Replace local helper**
+
+Delete:
+
+```ts
+function localizePocketBaseError(code: string | undefined, fallback: string): string {
+	if (code === 'validation_wallet_action_market_link_requires_install_app') {
+		return m.Wallet_action_market_link_requires_install_app();
+	}
+
+	return fallback;
+}
+```
+
+In the `ClientResponseError` catch block, replace both call sites:
+
+- `localizePocketBaseError(...)` → `localizePocketBaseErrorCode(...)`
+
+- [x] **Step 3: Typecheck / unit smoke**
+
+```sh
+cd webapp && bun run check
+cd webapp && bun run test:unit -- --run src/modules/utils/errors.test.ts
+```
+
+Expected: check succeeds (or only pre-existing unrelated errors); tests PASS.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Exact-match lookup helper | Task 1 |
+| Backend message fallback | Task 1 |
+| Rename i18n key to backend code | Task 2 |
+| Wire collection form; remove if-branch | Task 3 |
+| Unit tests hit/miss/undefined/non-callable | Task 1 |
+| Out of scope: other validation codes | — (not implemented) |
+| Out of scope: Go renames | — (not implemented) |

--- a/docs/superpowers/specs/2026-07-21-pocketbase-error-i18n-exact-match-design.md
+++ b/docs/superpowers/specs/2026-07-21-pocketbase-error-i18n-exact-match-design.md
@@ -1,0 +1,154 @@
+# PocketBase Validation Error i18n — Exact Match Design Spec
+
+**Date:** 2026-07-21  
+**Status:** Approved (design interview)  
+**Scope:** Replace the hardcoded PocketBase validation-code → `m` mapping in collection forms with exact-key lookup against Paraglide messages, aligned to backend `validation_*` codes.
+
+---
+
+## Summary
+
+The last PR added `localizePocketBaseError` with a single hardcoded branch:
+
+- backend code: `validation_wallet_action_market_link_requires_install_app`
+- i18n key: `Wallet_action_market_link_requires_install_app`
+
+That mapping does not scale and invents a second naming scheme.
+
+**Change:**
+
+1. **Canonical key** — backend PocketBase/ozzo validation `code` is the i18n message key (exact string match).
+2. **Rename** — change the existing wallet message key in all `webapp/messages/*.json` to `validation_wallet_action_market_link_requires_install_app`.
+3. **Lookup** — shared helper: if `code` exists on `m` and is a zero-arg (no required inputs) message function, call it; otherwise return the backend `message` fallback.
+4. **Wire** — collection form error handling uses the helper instead of the if-branch.
+
+**Out of scope:** Localizing other custom codes (`validation_pipeline_published_locked`, `validation_organization_public_entities`); renaming Go constants; transforming or stripping `validation_`; changing PocketBase built-in error UX beyond opt-in localization when a matching key exists.
+
+---
+
+## Problem
+
+| Aspect | Current | Desired |
+|--------|---------|---------|
+| Key relationship | Hand-mapped, names differ | Exact match |
+| Adding a new localized validation | Edit helper + messages | Add matching message key only |
+| Missing translation | N/A (hardcoded) | Show backend `message` |
+| Collision with UI labels (e.g. `Required`) | Transform would collide | Exact `validation_*` keys avoid UI collisions |
+
+---
+
+## Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Match strategy | Exact string equality between PB `code` and `m` key |
+| Canonical owner of the name | Backend `validation_*` code |
+| Rename direction | Rename i18n key to match backend (no Go rename) |
+| Missing key fallback | Backend `message` / `e.message` as today |
+| Implementation shape | Shared helper + unit tests (not an inline-only change) |
+| Other custom codes this pass | Do not add i18n keys yet |
+
+---
+
+## Contract
+
+### Backend → frontend
+
+PocketBase `ClientResponseError` field errors expose `{ code, message }`.
+
+- `code`: stable machine id (e.g. `validation_wallet_action_market_link_requires_install_app`)
+- `message`: human or code-echo fallback from the server
+
+### Localization rule
+
+```text
+if code is defined
+  and code is a key of m
+  and m[code] is a function callable with no required inputs
+then return m[code]()
+else return fallback (backend message)
+```
+
+### Adding a new localized validation error (future)
+
+1. Choose a stable `validation_…` code in Go (`validation.NewError(code, …)` / bad-request payload).
+2. Add the **same** string as a key in `webapp/messages/*.json`.
+3. No frontend mapper update required.
+
+---
+
+## Design
+
+### Helper
+
+Add `localizePocketBaseErrorCode` to `webapp/src/modules/utils/errors.ts` (alongside `getExceptionMessage`, which collection forms already use). Extend `errors.test.ts`.
+
+Responsibilities:
+
+- Accept `(code: string | undefined, fallback: string): string`
+- Perform exact-key lookup on `m`
+- Do not strip prefixes, capitalize, or otherwise transform `code`
+- Do not throw on unknown codes; always return a string
+
+Safety:
+
+- Only invoke message functions that need no required inputs (current custom validation messages are parameterless).
+- If a key exists but is not a safe zero-arg message function, return `fallback`.
+
+### Collection form
+
+`collectionFormSetup.ts` keeps calling the helper for:
+
+- per-field `data.code` / `data.message`
+- top-level form error using first field `code` and `e.message`
+
+Remove the wallet-specific if-branch.
+
+### Messages
+
+Rename in every locale file under `webapp/messages/`:
+
+- from: `Wallet_action_market_link_requires_install_app`
+- to: `validation_wallet_action_market_link_requires_install_app`
+
+Copy stays unchanged per locale. Paraglide regenerates `m` via the existing Vite plugin on next build/dev.
+
+### Tests
+
+Unit-test the helper:
+
+- known code present on a stub/`m` → localized string
+- unknown code → fallback
+- `undefined` code → fallback
+- key present but not a callable message → fallback
+
+No requirement for an E2E form test in this pass.
+
+---
+
+## Non-goals
+
+- Do not localize `validation_pipeline_published_locked` or `validation_organization_public_entities` unless a follow-up explicitly adds matching message keys.
+- Do not change Go error codes or English server messages for this feature.
+- Do not introduce a transform layer (`strip validation_`, PascalCase, etc.).
+- Do not attempt to localize arbitrary PocketBase built-in codes unless matching keys are deliberately added to `messages/*.json`.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Stale Paraglide output until vite regenerates | Rename source JSON; regeneration is existing project workflow |
+| Accidental collision if someone adds a UI string equal to a `validation_*` code | Unlikely; `validation_` prefix is the namespace; exact-match is intentional |
+| Parameterized Paraglide messages later | Helper only calls zero-required-input functions; otherwise fallback |
+
+---
+
+## Acceptance
+
+- Hardcoded wallet if-branch is gone.
+- Wallet validation code localizes when the matching `m` key exists.
+- Unknown codes still show the backend message.
+- All locale files use the renamed key.
+- Helper has unit coverage for hit / miss / undefined / non-callable.

--- a/webapp/messages/da.json
+++ b/webapp/messages/da.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "Handlinger, der åbner en Play Butik-appside, skal bruge kategorien install-app.",
+	"validation_wallet_action_market_link_requires_install_app": "Handlinger, der åbner en Play Butik-appside, skal bruge kategorien install-app.",
 	"accept_invite": "Accepter invitation",
 	"Accept": "Acceptere",
 	"accepted_files": "Accepterede filer",

--- a/webapp/messages/de.json
+++ b/webapp/messages/de.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "Aktionen, die eine Play-Store-App-Seite öffnen, müssen die Kategorie install-app verwenden.",
+	"validation_wallet_action_market_link_requires_install_app": "Aktionen, die eine Play-Store-App-Seite öffnen, müssen die Kategorie install-app verwenden.",
 	"accept_invite": "Einladung annehmen",
 	"Accept": "Akzeptieren",
 	"accepted_files": "Akzeptierte Dateien",

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "Actions opening a Play Store app page must use the install-app category.",
+	"validation_wallet_action_market_link_requires_install_app": "Actions opening a Play Store app page must use the install-app category.",
 	"accept_invite": "Accept invite",
 	"Accept": "Accept",
 	"accepted_files": "Accepted files",

--- a/webapp/messages/es-es.json
+++ b/webapp/messages/es-es.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "Las acciones que abren una página de aplicación de Play Store deben usar la categoría install-app.",
+	"validation_wallet_action_market_link_requires_install_app": "Las acciones que abren una página de aplicación de Play Store deben usar la categoría install-app.",
 	"accept_invite": "Aceptar invitación",
 	"Accept": "Aceptar",
 	"accepted_files": "Archivos aceptados",

--- a/webapp/messages/fr.json
+++ b/webapp/messages/fr.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "Les actions qui ouvrent une page d'application Play Store doivent utiliser la catégorie install-app.",
+	"validation_wallet_action_market_link_requires_install_app": "Les actions qui ouvrent une page d'application Play Store doivent utiliser la catégorie install-app.",
 	"accept_invite": "Accepter l'invitation",
 	"Accept": "Accepter",
 	"accepted_files": "Fichiers acceptés",

--- a/webapp/messages/it.json
+++ b/webapp/messages/it.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "Le azioni che aprono una pagina dell'app nel Play Store devono usare la categoria install-app.",
+	"validation_wallet_action_market_link_requires_install_app": "Le azioni che aprono una pagina dell'app nel Play Store devono usare la categoria install-app.",
 	"accept_invite": "Accetta l'invito",
 	"Accept": "Accettare",
 	"accepted_files": "File accettati",

--- a/webapp/messages/pt-BR.json
+++ b/webapp/messages/pt-BR.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"Wallet_action_market_link_requires_install_app": "As ações que abrem uma página de app da Play Store devem usar a categoria install-app.",
+	"validation_wallet_action_market_link_requires_install_app": "As ações que abrem uma página de app da Play Store devem usar a categoria install-app.",
 	"accept_invite": "Aceitar convite",
 	"Accept": "Aceitar",
 	"accepted_files": "Arquivos aceitos",

--- a/webapp/src/modules/collections-components/form/collectionFormSetup.ts
+++ b/webapp/src/modules/collections-components/form/collectionFormSetup.ts
@@ -27,7 +27,7 @@ import { m } from '@/i18n';
 import { pb } from '@/pocketbase';
 import { getCollectionModel } from '@/pocketbase/collections-models';
 import { createCollectionZodSchema } from '@/pocketbase/zod-schema';
-import { getExceptionMessage } from '@/utils/errors';
+import { getExceptionMessage, localizePocketBaseErrorCode } from '@/utils/errors';
 import { ensureArray } from '@/utils/other';
 
 import type { CollectionFormProps } from './collectionFormTypes';
@@ -154,12 +154,12 @@ export function setupCollectionForm<C extends CollectionName>({
 
 					const entries = Record.toEntries(details);
 					entries.forEach(([path, data]) => {
-						const message = localizePocketBaseError(data.code, data.message);
+						const message = localizePocketBaseErrorCode(data.code, data.message);
 						if (path in form.data) setError(form, path, message);
 						else setError(form, `${path} - ${message}`);
 					});
 
-					setError(form, localizePocketBaseError(entries[0]?.[1].code, e.message));
+					setError(form, localizePocketBaseErrorCode(entries[0]?.[1].code, e.message));
 				} else {
 					setError(form, getExceptionMessage(e));
 				}
@@ -170,14 +170,6 @@ export function setupCollectionForm<C extends CollectionName>({
 	//
 
 	return form as unknown as SuperForm<CollectionFormData[C]>;
-}
-
-function localizePocketBaseError(code: string | undefined, fallback: string): string {
-	if (code === 'validation_wallet_action_market_link_requires_install_app') {
-		return m.Wallet_action_market_link_requires_install_app();
-	}
-
-	return fallback;
 }
 
 //

--- a/webapp/src/modules/utils/errors.test.ts
+++ b/webapp/src/modules/utils/errors.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { exceptionToError, getExceptionMessage } from './errors';
+import { exceptionToError, getExceptionMessage, localizePocketBaseErrorCode } from './errors';
 
 describe('errors utils', () => {
 	it('returns the message for Error instances', () => {
@@ -25,5 +25,54 @@ describe('errors utils', () => {
 	it('returns Error values as-is', () => {
 		const err = new Error('keep');
 		expect(exceptionToError(err)).toBe(err);
+	});
+});
+
+describe('localizePocketBaseErrorCode', () => {
+	const catalog = {
+		validation_wallet_action_market_link_requires_install_app: () => 'Localized wallet error',
+		validation_not_a_function: 'oops',
+		validation_throws: () => {
+			throw new Error('needs inputs');
+		},
+		validation_non_string: () => 42
+	} as Record<string, unknown>;
+
+	it('returns localized string when code matches a message function', () => {
+		expect(
+			localizePocketBaseErrorCode(
+				'validation_wallet_action_market_link_requires_install_app',
+				'fallback',
+				catalog
+			)
+		).toBe('Localized wallet error');
+	});
+
+	it('returns fallback for unknown codes', () => {
+		expect(localizePocketBaseErrorCode('validation_unknown', 'fallback', catalog)).toBe(
+			'fallback'
+		);
+	});
+
+	it('returns fallback when code is undefined', () => {
+		expect(localizePocketBaseErrorCode(undefined, 'fallback', catalog)).toBe('fallback');
+	});
+
+	it('returns fallback when catalog value is not a function', () => {
+		expect(localizePocketBaseErrorCode('validation_not_a_function', 'fallback', catalog)).toBe(
+			'fallback'
+		);
+	});
+
+	it('returns fallback when message function throws', () => {
+		expect(localizePocketBaseErrorCode('validation_throws', 'fallback', catalog)).toBe(
+			'fallback'
+		);
+	});
+
+	it('returns fallback when message function returns a non-string', () => {
+		expect(localizePocketBaseErrorCode('validation_non_string', 'fallback', catalog)).toBe(
+			'fallback'
+		);
 	});
 });

--- a/webapp/src/modules/utils/errors.ts
+++ b/webapp/src/modules/utils/errors.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { m } from '@/i18n';
+
 export function getExceptionMessage(e: unknown): string {
 	if (e instanceof Error) {
 		return e.message;
@@ -15,6 +17,24 @@ export function exceptionToError(e: unknown): Error {
 		return e;
 	} else {
 		return new Error(`Unexpected error: ${JSON.stringify(e)}`);
+	}
+}
+
+export function localizePocketBaseErrorCode(
+	code: string | undefined,
+	fallback: string,
+	catalog: Record<string, unknown> = m as unknown as Record<string, unknown>
+): string {
+	if (!code) return fallback;
+
+	const candidate = catalog[code];
+	if (typeof candidate !== 'function') return fallback;
+
+	try {
+		const localized = (candidate as () => unknown)();
+		return typeof localized === 'string' ? localized : fallback;
+	} catch {
+		return fallback;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace the hardcoded PocketBase validation-code → `m` mapping with exact-key lookup (`localizePocketBaseErrorCode`)
- Rename the wallet validation message key to match the backend code `validation_wallet_action_market_link_requires_install_app`
- Fall back to the backend message when no matching Paraglide key exists

## Test plan
- [ ] `cd webapp && bun run test:unit -- --run src/modules/utils/errors.test.ts`
- [ ] `cd webapp && bun run check`
- [ ] Trigger wallet action validation (Play Store `market://details` link without `install-app`) and confirm the localized form error appears
- [ ] Trigger an unrelated PocketBase validation and confirm the backend message still shows


Made with [Cursor](https://cursor.com)