### PR TITLE
feat(hub): surface fcaf conformance suite

### DIFF
--- a/config_templates/fcaf/standard.yaml
+++ b/config_templates/fcaf/standard.yaml
@@ -1,0 +1,7 @@
+uid: fcaf
+name: EUDI Wallet FCAF
+description: Functional Conformance Assessment Framework for the European Digital Identity Wallet
+standard_url: https://conformance.eudi.dev/
+latest_update: 2026-03-13
+disabled: false
+external_links:

--- a/config_templates/fcaf/wallet_solution/relying_party/metadata.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/metadata.yaml
@@ -1,0 +1,8 @@
+name: Relying Party
+homepage: https://conformance.eudi.dev/
+repository: https://github.com/eu-digital-identity-wallet/eudi-doc-functional-conformance-assessment
+help: https://conformance.eudi.dev/latest/fcaf/using-fcaf/
+description: FCAF test cases for the wallet solution relying party role
+logo: https://raw.githubusercontent.com/eu-digital-identity-wallet/eudi-app-ios-wallet-ui/main/Wallet/Assets.xcassets/AppIcon.appiconset/app_icon.png
+visible_in:
+  - pipeline

--- a/config_templates/fcaf/wallet_solution/version.yaml
+++ b/config_templates/fcaf/wallet_solution/version.yaml
@@ -1,0 +1,3 @@
+name: Wallet Solution
+latest_update: 2026-03-13
+specification_url: https://conformance.eudi.dev/

--- a/pkg/internal/apis/handlers/templates_handlers.go
+++ b/pkg/internal/apis/handlers/templates_handlers.go
@@ -184,7 +184,6 @@ type Standards []Standard
 // conformance-check standards and must not appear in the template
 // blueprints listing.
 var nonStandardTemplateDirs = map[string]struct{}{
-	"fcaf":         {},
 	"fcaf_sources": {},
 }
 
@@ -268,11 +267,13 @@ func walkConfigTemplates(dir string, surface string) (Standards, error) {
 			versionUID := vEntry.Name()
 			versionPath := filepath.Join(standardPath, versionUID)
 
+			versionYamlPath := filepath.Join(versionPath, "version.yaml")
+			if _, err := os.Stat(versionYamlPath); err != nil {
+				continue
+			}
+
 			versionMeta := VersionMetadata{UID: versionUID}
-			if err := readYaml(
-				filepath.Join(versionPath, "version.yaml"),
-				&versionMeta,
-			); err != nil {
+			if err := readYaml(versionYamlPath, &versionMeta); err != nil {
 				return nil, err
 			}
 
@@ -289,11 +290,13 @@ func walkConfigTemplates(dir string, surface string) (Standards, error) {
 				suiteUID := sEntry.Name()
 				suitePath := filepath.Join(versionPath, suiteUID)
 
+				metadataYamlPath := filepath.Join(suitePath, "metadata.yaml")
+				if _, err := os.Stat(metadataYamlPath); err != nil {
+					continue
+				}
+
 				suiteMeta := SuiteMetadata{UID: suiteUID}
-				if err := readYaml(
-					filepath.Join(suitePath, "metadata.yaml"),
-					&suiteMeta,
-				); err != nil {
+				if err := readYaml(metadataYamlPath, &suiteMeta); err != nil {
 					return nil, err
 				}
 

--- a/pkg/internal/apis/handlers/templates_handlers_test.go
+++ b/pkg/internal/apis/handlers/templates_handlers_test.go
@@ -46,7 +46,7 @@ func TestWalkConfigTemplates(t *testing.T) {
 	)
 
 	// Non-standard data directories must be excluded from blueprints.
-	for _, skipUID := range []string{"fcaf", "fcaf_sources"} {
+	for _, skipUID := range []string{"fcaf_sources"} {
 		skipDir := filepath.Join(testdataDir, skipUID)
 		require.NoError(t, os.Mkdir(skipDir, 0755))
 		skipYaml, _ := yaml.Marshal(StandardMetadata{UID: skipUID, Name: skipUID})
@@ -120,6 +120,18 @@ func TestWalkConfigTemplates(t *testing.T) {
 	}
 	suite3Yaml, _ := yaml.Marshal(suite3Meta)
 	require.NoError(t, os.WriteFile(filepath.Join(suite3Dir, "metadata.yaml"), suite3Yaml, 0644))
+
+	// Directories without version.yaml or metadata.yaml must be skipped, not
+	// surfaced as blank versions or suites (e.g. FCAF data directories).
+	noVersionDir := filepath.Join(standardDir, "no_version_dir")
+	require.NoError(t, os.Mkdir(noVersionDir, 0755))
+
+	noMetaSuiteDir := filepath.Join(versionDir, "no_metadata_suite")
+	require.NoError(t, os.Mkdir(noMetaSuiteDir, 0755))
+	require.NoError(
+		t,
+		os.WriteFile(filepath.Join(noMetaSuiteDir, "orphan.json"), []byte("{}"), 0644),
+	)
 
 	wantUnfiltered := Standards{
 		Standard{

--- a/webapp/src/lib/pipeline-form/steps/fcaf-validation/grouping.ts
+++ b/webapp/src/lib/pipeline-form/steps/fcaf-validation/grouping.ts
@@ -21,11 +21,18 @@ export function categoryLabel(section: string): string {
 	return humanize(section.split('.')[0] ?? section);
 }
 
+export function groupAllTests(): FCAFGroupedTests[] {
+	return groupTests(FCAF_TESTS);
+}
+
 export function groupSelectedTests(testIds: string[]): FCAFGroupedTests[] {
 	const selected = new Set(testIds);
+	return groupTests(FCAF_TESTS.filter((test) => selected.has(test.id)));
+}
+
+function groupTests(tests: FCAFTestCatalogEntry[]): FCAFGroupedTests[] {
 	const acc: Record<string, FCAFTestCatalogEntry[]> = {};
-	for (const test of FCAF_TESTS) {
-		if (!selected.has(test.id)) continue;
+	for (const test of tests) {
 		const key = test.section || 'other';
 		(acc[key] ??= []).push(test);
 	}

--- a/webapp/src/routes/(public)/hub/conformance-checks/[...path]/_partials/collection-page.svelte
+++ b/webapp/src/routes/(public)/hub/conformance-checks/[...path]/_partials/collection-page.svelte
@@ -14,6 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import PageSection from '../../../[...path]/_partials/_utils/page-section.svelte';
 	import { sections as s } from '../../../[...path]/_partials/_utils/sections';
 	import CheckCard from './components/check-card.svelte';
+	import FcafTests from './components/fcaf-tests.svelte';
 	import PageLayout from './components/page-layout.svelte';
 
 	//
@@ -42,11 +43,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		</PageSection>
 
 		<PageSection indexItem={s.checks}>
-			<div class="space-y-2">
-				{#each suite.paths as path (path)}
-					<CheckCard {standard} {version} {suite} test={path} />
-				{/each}
-			</div>
+			{#if standard.uid === 'fcaf'}
+				<FcafTests />
+			{:else}
+				<div class="space-y-2">
+					{#each suite.paths as path (path)}
+						<CheckCard {standard} {version} {suite} test={path} />
+					{/each}
+				</div>
+			{/if}
 		</PageSection>
 	{/snippet}
 </PageLayout>

--- a/webapp/src/routes/(public)/hub/conformance-checks/[...path]/_partials/components/fcaf-tests.svelte
+++ b/webapp/src/routes/(public)/hub/conformance-checks/[...path]/_partials/components/fcaf-tests.svelte
@@ -1,0 +1,98 @@
+<!--
+SPDX-FileCopyrightText: 2026 Forkbomb BV
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+	import type { FCAFGroupedTests } from '$lib/pipeline-form/steps/fcaf-validation/grouping.js';
+
+	import { ChevronRightIcon } from '@lucide/svelte';
+	import { groupAllTests } from '$lib/pipeline-form/steps/fcaf-validation/grouping.js';
+
+	import { Input } from '@/components/ui/input';
+	import { m } from '@/i18n';
+
+	//
+
+	let search = $state('');
+	let openGroups = $state<Record<string, boolean>>({});
+
+	const searching = $derived(search.trim() !== '');
+
+	const groups: FCAFGroupedTests[] = $derived.by(() => {
+		const query = search.trim().toLowerCase();
+		const all = groupAllTests();
+		if (!query) return all;
+		return all
+			.map((group) => ({
+				...group,
+				tests: group.tests.filter(
+					(test) =>
+						test.id.toLowerCase().includes(query) ||
+						test.title.toLowerCase().includes(query) ||
+						test.section.toLowerCase().includes(query)
+				)
+			}))
+			.filter((group) => group.tests.length > 0);
+	});
+
+	const totalTests = $derived(groups.reduce((sum, group) => sum + group.tests.length, 0));
+
+	function isOpen(key: string): boolean {
+		return searching || (openGroups[key] ?? false);
+	}
+
+	function toggleOpen(key: string) {
+		openGroups[key] = !(openGroups[key] ?? false);
+	}
+</script>
+
+<div class="rounded-md border">
+	<div class="border-b p-2">
+		<Input bind:value={search} placeholder={m.Search()} />
+	</div>
+	<div class="flex items-center justify-between gap-2 border-b px-3 py-2">
+		<span class="text-xs text-muted-foreground">{totalTests} {m.Tests()}</span>
+	</div>
+	<div class="max-h-96 overflow-y-auto p-1">
+		{#each groups as group (group.key)}
+			<div class="rounded">
+				<button
+					type="button"
+					class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-muted/50"
+					onclick={() => toggleOpen(group.key)}
+				>
+					<ChevronRightIcon
+						class="size-4 shrink-0 text-muted-foreground transition-transform {isOpen(
+							group.key
+						)
+							? 'rotate-90'
+							: ''}"
+					/>
+					<span class="truncate text-sm font-medium">{group.label}</span>
+					<span class="shrink-0 text-xs text-muted-foreground">{group.category}</span>
+					<span class="ml-auto shrink-0 text-xs text-muted-foreground">
+						{group.tests.length}
+					</span>
+				</button>
+				{#if isOpen(group.key)}
+					<div class="space-y-0.5 pb-1 pl-9">
+						{#each group.tests as test (test.id)}
+							<div class="rounded px-2 py-1">
+								<div class="truncate font-mono text-xs" title={test.id}>
+									{test.id}
+								</div>
+								{#if test.title}
+									<div class="line-clamp-2 text-xs text-muted-foreground">
+										{test.title}
+									</div>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
+</div>


### PR DESCRIPTION
## What

Surface the FCAF wallet-solution relying-party suite in the public hub conformance-checks page.

## Why

FCAF was excluded from the template blueprints listing and had no standard/version/suite metadata, so it never appeared in the hub.

## Changes

- Add `standard.yaml`, `version.yaml`, and suite `metadata.yaml` for the FCAF suite (EUDI Wallet FCAF / Wallet Solution / Relying Party) with the official EUDI Wallet app icon.
- Allow the `fcaf` directory into the blueprints walker; keep `fcaf_sources` excluded.
- Skip directories without `version.yaml`/`metadata.yaml` so FCAF data folders (`tests`, `scenarios`, `pipelines`, `imports`) don't leak as blank standards/suites.
- Show the FCAF tests on the suite page as a read-only, grouped, collapsible, searchable list (reusing the pipeline editor grouping), instead of startable check cards.

## Validation

- `make lint` (go mod tidy -diff, go mod verify, go vet, govulncheck, golangci-lint): clean
- Go: `go test ./pkg/internal/apis/handlers/...` pass
- Webapp: `bun run check` 0 errors, eslint clean, `bun run test:unit -- --run` 159 pass, `bun run build` success