### PR TITLE
perf(fcaf): lazy load report screenshots and defer json fetch

### DIFF
--- a/webapp/src/lib/components/lazy-image.svelte
+++ b/webapp/src/lib/components/lazy-image.svelte
@@ -1,0 +1,86 @@
+<!--
+SPDX-FileCopyrightText: 2026 Forkbomb BV
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+	import type { ClassValue } from 'svelte/elements';
+
+	type Props = {
+		src: string;
+		alt?: string;
+		class?: ClassValue;
+		width?: number | string;
+		height?: number | string;
+		loading?: 'lazy' | 'eager';
+		decoding?: 'async' | 'sync' | 'auto';
+	};
+
+	let {
+		src,
+		alt = '',
+		class: className,
+		width,
+		height,
+		loading = 'lazy',
+		decoding = 'async'
+	}: Props = $props();
+
+	let element = $state<HTMLImageElement | null>(null);
+	let shouldLoad = $state(false);
+
+	/**
+	 * Native `loading="lazy"` only defers against the document viewport, so images
+	 * inside an `overflow-y: auto` panel (like a sheet) are not deferred correctly.
+	 * Walk up to the nearest scrollable ancestor and observe that instead.
+	 */
+	function closestScrollable(el: HTMLElement | null): HTMLElement | null {
+		let current = el?.parentElement ?? null;
+		while (current) {
+			const { overflowY } = getComputedStyle(current);
+			if (
+				(overflowY === 'auto' || overflowY === 'scroll') &&
+				current.scrollHeight > current.clientHeight
+			) {
+				return current;
+			}
+			current = current.parentElement;
+		}
+		return null;
+	}
+
+	$effect(() => {
+		const el = element;
+		if (!el) return;
+		if (shouldLoad) return;
+
+		if (typeof IntersectionObserver === 'undefined') {
+			shouldLoad = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					shouldLoad = true;
+					observer.disconnect();
+				}
+			},
+			{ root: closestScrollable(el), rootMargin: '600px 0px' }
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	});
+</script>
+
+<img
+	bind:this={element}
+	src={shouldLoad ? src : undefined}
+	{alt}
+	{width}
+	{height}
+	{loading}
+	{decoding}
+	class={className}
+/>

--- a/webapp/src/lib/components/media-preview.svelte
+++ b/webapp/src/lib/components/media-preview.svelte
@@ -8,6 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import type { ClassValue } from 'svelte/elements';
 
 	import { BadgeCheckIcon, FileCogIcon, FileIcon, ImageIcon, VideoIcon } from '@lucide/svelte';
+	import LazyImage from '$lib/components/lazy-image.svelte';
 
 	import type { IconComponent } from '@/components/types';
 
@@ -58,7 +59,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 {#snippet content()}
 	{#if image}
-		<img src={image} alt="Media" class="size-10 shrink-0" />
+		<LazyImage src={image} alt="Media" class="size-10 shrink-0" />
 	{/if}
 	<div class="absolute inset-0 flex items-center justify-center bg-black/30">
 		<Icon src={iconComponent} class="size-4  text-white" />

--- a/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
+++ b/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
@@ -8,6 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import type { Snippet } from 'svelte';
 
 	import { DownloadIcon, ExternalLinkIcon } from '@lucide/svelte';
+	import LazyImage from '$lib/components/lazy-image.svelte';
 	import CodeDisplay from '$lib/layout/codeDisplay.svelte';
 	import { activeSheet } from '$lib/utils/sheet-state.svelte';
 	import { SvelteSet } from 'svelte/reactivity';
@@ -153,15 +154,19 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			activeSheet.close();
 		}
 	});
-	const reportPromise = $derived(
-		reportUrl
-			? fetch(reportUrl).then(async (response) => {
-					if (!response.ok)
-						throw new Error(`FCAF report request failed: ${response.status}`);
-					return (await response.json()) as Report;
-				})
-			: undefined
-	);
+	// Fetch lazily: only once the sheet is opened, not for every run row that has a report.
+	let cachedReport: Promise<Report | undefined> | undefined;
+
+	const reportPromise = $derived.by(() => {
+		if (!reportUrl) return undefined;
+		if (!sheetOpen) return cachedReport;
+		return (cachedReport ??= fetch(reportUrl)
+			.then(async (response) => {
+				if (!response.ok) throw new Error(`FCAF report request failed: ${response.status}`);
+				return (await response.json()) as Report;
+			})
+			.catch(() => undefined));
+	});
 
 	function statusClass(status = '') {
 		if (['passed', 'pass'].includes(status)) return 'text-green-700';
@@ -348,11 +353,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 																	rel="noreferrer"
 																	class="block overflow-hidden rounded border bg-muted/20"
 																>
-																	<img
+																	<LazyImage
 																		src={screenshot.url}
 																		alt={screenshot.label}
 																		class="aspect-video h-auto w-full object-contain"
-																		loading="lazy"
 																	/>
 																	<div
 																		class="px-2 py-1 text-xs break-all text-muted-foreground"
@@ -382,11 +386,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 											rel="noreferrer"
 											class="block overflow-hidden rounded border bg-muted/20"
 										>
-											<img
+											<LazyImage
 												src={screenshot.url}
 												alt={screenshot.label}
 												class="aspect-video h-auto w-full object-contain"
-												loading="lazy"
 											/>
 											<div
 												class="px-2 py-1 text-xs break-all text-muted-foreground"


### PR DESCRIPTION
## What

Lazy-load FCAF report visuals so run-heavy `/my/pipelines` pages stay light.

## Why

- FCAF report sheet images are inside a nested `overflow-y-auto` panel. Native `loading="lazy"` defers only against the document viewport, so it never worked there — every screenshot fetched at once when the report opened.
- The FCAF report JSON was fetched on mount for every run row that has a report, even when the sheet was never opened.
- Run screenshot thumbnails (`MediaPreview`) had no lazy loading at all.

## Changes

- New `webapp/src/lib/components/lazy-image.svelte`: IntersectionObserver-based image that observes the nearest scrollable ancestor and sets `src` only when near the visible area (600px margin). Falls back to immediate load without IntersectionObserver.
- `fcaf-report-sheet.svelte`: screenshots use `LazyImage`; report JSON now fetches lazily on sheet open (cached, errors swallowed to "Unable to load").
- `media-preview.svelte`: thumbnail `<img>` uses `LazyImage`.

## Validation

- `bun run lint` (prettier + eslint): pass
- `bun run check`: changed files clean (pre-existing errors elsewhere untouched)
- focused unit test `execution-artifacts.test.ts`: pass