### PR TITLE
feat(fcaf): group assessment checks by area in sheet and PDF

### DIFF
--- a/pkg/fcaf/reportpdf/categories.go
+++ b/pkg/fcaf/reportpdf/categories.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package reportpdf
+
+import (
+	"strings"
+	"unicode"
+)
+
+// categoryMeta carries the display name and accent colour for one FCAF area.
+// Colours mirror the webapp --fcaf-* tokens so the PDF and the web report stay
+// visually consistent.
+type categoryMeta struct {
+	name  string
+	color [3]int
+}
+
+// categoryOrder is the canonical display order, matching the webapp
+// FCAF_CATEGORY_ORDER. It is authoritative because executed-test order alone
+// would sort areas alphabetically (DM, IA, MS, …) rather than by FCAF flow.
+var categoryOrder = []string{"DM", "MS", "IA", "SM", "SH", "UC", "OTHER"}
+
+var categoryByCode = map[string]categoryMeta{
+	"DM":    {"Data model", [3]int{78, 91, 210}},
+	"MS":    {"Message structure", [3]int{14, 148, 160}},
+	"IA":    {"Interaction", [3]int{201, 122, 20}},
+	"SM":    {"Security mechanisms", [3]int{185, 49, 139}},
+	"SH":    {"Shared", [3]int{31, 138, 92}},
+	"UC":    {"Use cases", [3]int{142, 122, 18}},
+	"OTHER": {"Other", [3]int{99, 99, 109}},
+}
+
+var subgroupLabels = map[string]string{
+	"addressdata":        "Address data",
+	"identifyingdata":    "Identifying data",
+	"credentialmetadata": "Credential metadata",
+	"protocolmessages":   "Protocol messages",
+	"metadata":           "Metadata",
+	"credentialformats":  "Credential formats",
+	"maininteraction":    "Main interaction",
+	"engagement":         "Engagement",
+	"protocolflow":       "Protocol flow",
+	"supportive":         "Supportive",
+	"rpintegrity":        "RP integrity",
+	"trustmechanisms":    "Trust mechanisms",
+	"sessionencryption":  "Session encryption",
+	"devicebinding":      "Device binding",
+	"sessionbinding":     "Session binding",
+	"issuerintegrity":    "Issuer integrity",
+	"encoding":           "Encoding",
+	"cryptography":       "Cryptography",
+	"presentation":       "Presentation",
+}
+
+// parseTestID derives the FCAF area and subsection from a test identifier of
+// the form WS_RP_<CATEGORY>_<SUBGROUP>_<specifics>[_|__]<NNN>. Test identifiers
+// are the stable source of truth: the suite.section field mixes semantic paths
+// with ARF clause references and cannot be relied upon.
+func parseTestID(testID string) (code, subgroup, label string) {
+	parts := strings.Split(testID, "_")
+	if len(parts) >= 4 && parts[0] == "WS" && parts[1] == "RP" {
+		code = strings.ToUpper(parts[2])
+		if _, ok := categoryByCode[code]; ok {
+			subgroup = strings.ToLower(parts[3])
+			return code, subgroup, subgroupLabel(subgroup)
+		}
+	}
+	return "OTHER", "other", "Other"
+}
+
+func subgroupLabel(key string) string {
+	if label, ok := subgroupLabels[key]; ok {
+		return label
+	}
+	return humanize(key)
+}
+
+// humanize turns a CamelCase segment into space-separated words, used only for
+// subgroups not yet present in subgroupLabels.
+func humanize(segment string) string {
+	if segment == "" {
+		return ""
+	}
+	var sb strings.Builder
+	runes := []rune(segment)
+	sb.WriteRune(unicode.ToUpper(runes[0]))
+	for i := 1; i < len(runes); i++ {
+		if unicode.IsUpper(runes[i]) {
+			sb.WriteByte(' ')
+		}
+		sb.WriteRune(runes[i])
+	}
+	return sb.String()
+}

--- a/pkg/fcaf/reportpdf/categories_test.go
+++ b/pkg/fcaf/reportpdf/categories_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package reportpdf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTestID(t *testing.T) {
+	tests := []struct {
+		name     string
+		testID   string
+		code     string
+		subgroup string
+		label    string
+	}{
+		{
+			name:     "data model single underscore",
+			testID:   "WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_001",
+			code:     "DM",
+			subgroup: "addressdata",
+			label:    "Address data",
+		},
+		{
+			name:     "interaction double underscore",
+			testID:   "WS_RP_IA_MainInteraction__003",
+			code:     "IA",
+			subgroup: "maininteraction",
+			label:    "Main interaction",
+		},
+		{
+			name:     "credential metadata casing variants normalize",
+			testID:   "WS_RP_DM_Credentialmetadata_X_001",
+			code:     "DM",
+			subgroup: "credentialmetadata",
+			label:    "Credential metadata",
+		},
+		{
+			name:     "rp integrity acronym",
+			testID:   "WS_RP_SM_RpIntegrity_Signed_001",
+			code:     "SM",
+			subgroup: "rpintegrity",
+			label:    "RP integrity",
+		},
+		{
+			name:     "unknown category falls back to other",
+			testID:   "WS_RP_TEST__001",
+			code:     "OTHER",
+			subgroup: "other",
+			label:    "Other",
+		},
+		{
+			name:     "non ws rp prefix falls back to other",
+			testID:   "SOMETHING_ELSE",
+			code:     "OTHER",
+			subgroup: "other",
+			label:    "Other",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, subgroup, label := parseTestID(tc.testID)
+			require.Equal(t, tc.code, code)
+			require.Equal(t, tc.subgroup, subgroup)
+			require.Equal(t, tc.label, label)
+		})
+	}
+}

--- a/pkg/fcaf/reportpdf/model.go
+++ b/pkg/fcaf/reportpdf/model.go
@@ -25,6 +25,13 @@ type Metadata struct {
 	RunID              string
 	GeneratedAt        time.Time
 	JSONFilename       string
+	Runner             RunnerInfo
+}
+
+type RunnerInfo struct {
+	Name   string
+	Type   string
+	Serial string
 }
 
 type ImageAsset struct {
@@ -47,11 +54,18 @@ type Document struct {
 	Report        engine.Report
 	Metadata      Metadata
 	JSONSHA256    string
-	Groups        []TestGroup
+	Categories    []Category
 	Evidence      []EvidenceEntry
 	Unassigned    []ImageAsset
 	Warnings      []string
 	SelectedCount int
+}
+
+type Category struct {
+	Code   string
+	Name   string
+	Color  [3]int
+	Groups []TestGroup
 }
 
 type TestGroup struct {
@@ -93,16 +107,20 @@ func BuildDocument(input Input) Document {
 		imagesByEvidence[image.EvidenceKey] = append(imagesByEvidence[image.EvidenceKey], image)
 	}
 
-	groupIndex := map[string]int{}
+	categoryGroups := map[string]map[string]*TestGroup{}
 	referencedEvidence := map[string]struct{}{}
 	assignedImages := map[string]struct{}{}
 	for _, execution := range input.Report.ExecutedTests {
-		groupName := testGroupName(execution.TestID)
-		index, found := groupIndex[groupName]
-		if !found {
-			index = len(document.Groups)
-			groupIndex[groupName] = index
-			document.Groups = append(document.Groups, TestGroup{Name: groupName})
+		code, subgroup, label := parseTestID(execution.TestID)
+		groups, ok := categoryGroups[code]
+		if !ok {
+			groups = map[string]*TestGroup{}
+			categoryGroups[code] = groups
+		}
+		group, ok := groups[subgroup]
+		if !ok {
+			group = &TestGroup{Name: label}
+			groups[subgroup] = group
 		}
 
 		entry := TestEntry{
@@ -130,7 +148,25 @@ func BuildDocument(input Input) Document {
 				assignedImages[image.Filename] = struct{}{}
 			}
 		}
-		document.Groups[index].Tests = append(document.Groups[index].Tests, entry)
+		group.Tests = append(group.Tests, entry)
+	}
+
+	for _, code := range categoryOrder {
+		groups, ok := categoryGroups[code]
+		if !ok {
+			continue
+		}
+		keys := make([]string, 0, len(groups))
+		for key := range groups {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		meta := categoryByCode[code]
+		category := Category{Code: code, Name: meta.name, Color: meta.color}
+		for _, key := range keys {
+			category.Groups = append(category.Groups, *groups[key])
+		}
+		document.Categories = append(document.Categories, category)
 	}
 
 	keys := make([]string, 0, len(input.Report.Evidence))
@@ -166,14 +202,16 @@ func BuildDocument(input Input) Document {
 	for _, filename := range imageNames {
 		image := allImages[filename]
 		matched := false
-		for groupIndex := range document.Groups {
-			for testIndex := range document.Groups[groupIndex].Tests {
-				if screenshotMatchesTest(filename, document.Groups[groupIndex].Tests[testIndex]) {
-					appendImageUnique(
-						&document.Groups[groupIndex].Tests[testIndex].Images,
-						image,
-					)
-					matched = true
+		for categoryIndex := range document.Categories {
+			for groupIndex := range document.Categories[categoryIndex].Groups {
+				for testIndex := range document.Categories[categoryIndex].Groups[groupIndex].Tests {
+					if screenshotMatchesTest(filename, document.Categories[categoryIndex].Groups[groupIndex].Tests[testIndex]) {
+						appendImageUnique(
+							&document.Categories[categoryIndex].Groups[groupIndex].Tests[testIndex].Images,
+							image,
+						)
+						matched = true
+					}
 				}
 			}
 		}
@@ -237,14 +275,4 @@ func testEvidenceKeys(test engine.ExecutedTest) []string {
 	}
 	sort.Strings(keys)
 	return keys
-}
-
-func testGroupName(testID string) string {
-	if index := strings.LastIndex(testID, "__"); index > 0 {
-		return testID[:index]
-	}
-	if strings.TrimSpace(testID) == "" {
-		return "Other"
-	}
-	return testID
 }

--- a/pkg/fcaf/reportpdf/render.go
+++ b/pkg/fcaf/reportpdf/render.go
@@ -29,6 +29,12 @@ type renderer struct {
 	pdf              *fpdf.Fpdf
 	document         Document
 	registeredImages map[string]string
+	section          string
+	sectionColor     [3]int
+	testProgress     string
+	testCount        int
+	evidenceCount    int
+	onBackCover      bool
 }
 
 func Render(ctx context.Context, document Document) ([]byte, error) {
@@ -101,28 +107,39 @@ func (r *renderer) installHeaderAndFooter() {
 		r.pdf.Line(pageMargin, 16, pageWidth-pageMargin, 16)
 	}, true)
 	r.pdf.SetFooterFunc(func() {
+		if r.onBackCover {
+			return
+		}
 		r.pdf.SetY(-14)
 		r.pdf.SetDrawColor(225, 222, 237)
 		r.pdf.Line(pageMargin, r.pdf.GetY(), pageWidth-pageMargin, r.pdf.GetY())
 		r.pdf.SetY(-11)
 		r.pdf.SetFont("SourceCodePro", "", 7)
 		r.pdf.SetTextColor(100, 98, 112)
-		identifier := strings.TrimSpace(r.document.Metadata.WorkflowID)
-		if identifier == "" {
-			identifier = "FCAF assessment"
+
+		left := r.section
+		hasSection := left != ""
+		if !hasSection {
+			left = strings.TrimSpace(r.document.Metadata.WorkflowID)
+			if left == "" {
+				left = "FCAF assessment"
+			}
 		}
-		r.pdf.CellFormat(bodyWidth/2, 5, identifier, "", 0, "L", false, 0, "")
-		r.pdf.CellFormat(
-			bodyWidth/2,
-			5,
-			fmt.Sprintf("Page %d of {nb}", r.pdf.PageNo()),
-			"",
-			0,
-			"R",
-			false,
-			0,
-			"",
-		)
+
+		leftWidth := bodyWidth / 2
+		if hasSection {
+			r.pdf.SetFillColor(r.sectionColor[0], r.sectionColor[1], r.sectionColor[2])
+			r.pdf.Rect(pageMargin, r.pdf.GetY()+0.5, 1.5, 4.5, "F")
+			r.pdf.SetXY(pageMargin+5, r.pdf.GetY())
+			leftWidth -= 5
+		}
+		r.pdf.CellFormat(leftWidth, 5, left, "", 0, "L", false, 0, "")
+
+		right := fmt.Sprintf("Page %d of {nb}", r.pdf.PageNo())
+		if r.testProgress != "" {
+			right = r.testProgress + " · " + right
+		}
+		r.pdf.CellFormat(bodyWidth/2, 5, right, "", 0, "R", false, 0, "")
 	})
 }
 
@@ -132,15 +149,17 @@ func (r *renderer) render() error {
 	}
 	r.renderCover()
 	r.renderExecutiveSummary()
-	for _, group := range r.document.Groups {
+	r.renderGroupSummary()
+	for _, category := range r.document.Categories {
 		if err := r.checkContext(); err != nil {
 			return err
 		}
-		r.renderGroup(group)
+		r.renderCategory(category)
 	}
 	r.renderEvidenceIndex()
 	r.renderUnassignedImages()
 	r.renderWarnings()
+	r.renderBackCover()
 	return r.pdf.Error()
 }
 
@@ -186,6 +205,15 @@ func (r *renderer) renderCover() {
 		firstNonEmpty(r.document.Metadata.OrganizationName, "—"),
 		false,
 	)
+	if r.document.Metadata.Runner.Name != "" {
+		r.renderMetadataRow("Runner", r.document.Metadata.Runner.Name, false)
+	}
+	if r.document.Metadata.Runner.Type != "" {
+		r.renderMetadataRow("Runner type", r.document.Metadata.Runner.Type, false)
+	}
+	if r.document.Metadata.Runner.Serial != "" {
+		r.renderMetadataRow("Serial", r.document.Metadata.Runner.Serial, true)
+	}
 	r.renderMetadataRow("Workflow ID", firstNonEmpty(r.document.Metadata.WorkflowID, "—"), true)
 	r.renderMetadataRow("Run ID", firstNonEmpty(r.document.Metadata.RunID, "—"), true)
 	date := "—"
@@ -193,6 +221,73 @@ func (r *renderer) renderCover() {
 		date = r.document.Metadata.GeneratedAt.Format("02/01/2006")
 	}
 	r.renderMetadataRow("Report date", date, true)
+	r.pdf.Ln(10)
+	r.pdf.SetFont("Inter", "M", 9)
+	r.pdf.SetTextColor(41, 18, 120)
+	r.pdf.CellFormat(bodyWidth, 6, "By Forkbomb BV", "", 0, "L", false, 0, "")
+}
+
+func (r *renderer) renderBackCover() {
+	r.pdf.AddPage()
+	r.onBackCover = true
+	r.pdf.Bookmark("About Credimi", 0, -1)
+
+	r.pdf.SetFillColor(239, 236, 252)
+	r.pdf.Rect(0, 0, pageWidth, pageHeight, "F")
+
+	r.pdf.ImageOptions(
+		"credimi-wordmark",
+		(pageWidth-90)/2,
+		34,
+		90,
+		0,
+		false,
+		fpdf.ImageOptions{ImageType: "PNG"},
+		0,
+		"",
+	)
+
+	r.pdf.SetXY(pageMargin, 92)
+	r.pdf.SetFont("Inter", "B", 19)
+	r.pdf.SetTextColor(41, 18, 120)
+	r.pdf.MultiCell(bodyWidth, 10, "Your trustworthy compliance checker", "", "C", false)
+	r.pdf.SetFont("Inter", "", 12)
+	r.pdf.SetTextColor(70, 68, 86)
+	r.pdf.MultiCell(bodyWidth, 7, "for decentralized identity solutions", "", "C", false)
+
+	r.pdf.Ln(16)
+	r.pdf.SetFont("Inter", "", 10)
+	r.pdf.SetTextColor(70, 68, 86)
+	r.pdf.MultiCell(
+		bodyWidth,
+		6,
+		"Credimi automates FCAF conformance assessment for EUDI wallets and relying parties.",
+		"",
+		"C",
+		false,
+	)
+
+	r.pdf.Ln(20)
+	r.pdf.SetFont("Inter", "B", 11)
+	r.pdf.SetTextColor(41, 18, 120)
+	r.pdf.MultiCell(bodyWidth, 7, "Get in touch", "", "C", false)
+	r.pdf.Ln(3)
+
+	contacts := []string{
+		"credimi.io",
+		"docs.credimi.io",
+		"info@forkbomb.com",
+	}
+	for _, contact := range contacts {
+		r.pdf.SetFont("SourceCodePro", "", 9.5)
+		r.pdf.SetTextColor(70, 68, 86)
+		r.pdf.MultiCell(bodyWidth, 6.5, contact, "", "C", false)
+	}
+
+	r.pdf.Ln(24)
+	r.pdf.SetFont("Inter", "", 8)
+	r.pdf.SetTextColor(100, 98, 112)
+	r.pdf.MultiCell(bodyWidth, 5, "© Forkbomb BV. All rights reserved.", "", "C", false)
 }
 
 func (r *renderer) renderMetadataRow(label, value string, monospace bool) {
@@ -266,10 +361,78 @@ func (r *renderer) renderExecutiveSummary() {
 	}
 }
 
-func (r *renderer) renderGroup(group TestGroup) {
+func (r *renderer) renderGroupSummary() {
 	r.pdf.AddPage()
-	r.pdf.Bookmark(group.Name, 0, -1)
-	r.heading(1, group.Name)
+	r.pdf.Bookmark("Test groups", 0, -1)
+	r.heading(1, "Test groups")
+	r.paragraph(
+		"Conformance checks are organised by FCAF area and subsection. Each area is colour-coded throughout this report.",
+	)
+
+	r.ensureSpace(10)
+	r.pdf.SetFont("Inter", "M", 8.5)
+	r.pdf.SetTextColor(100, 98, 112)
+	r.pdf.CellFormat(bodyWidth, 5, "Colour key", "", 0, "L", false, 0, "")
+	r.pdf.Ln(6)
+	for _, category := range r.document.Categories {
+		r.colorSwatch(category.Color, category.Name)
+	}
+
+	r.pdf.Ln(4)
+	r.heading(2, "Areas under test:")
+	for _, category := range r.document.Categories {
+		r.ensureSpace(18)
+		r.coloredHeading(1, category.Name, category.Color)
+		passed, total := 0, 0
+		for _, group := range category.Groups {
+			for _, test := range group.Tests {
+				total++
+				if strings.HasPrefix(strings.ToLower(test.Execution.Status), "pass") {
+					passed++
+				}
+			}
+		}
+		r.paragraph(fmt.Sprintf("%d over %d tests passed", passed, total))
+		for _, group := range category.Groups {
+			groupPassed := 0
+			for _, test := range group.Tests {
+				if strings.HasPrefix(strings.ToLower(test.Execution.Status), "pass") {
+					groupPassed++
+				}
+			}
+			r.summaryRow(group.Name, groupPassed, len(group.Tests), category.Color)
+		}
+	}
+}
+
+func (r *renderer) renderCategory(category Category) {
+	r.pdf.AddPage()
+	r.pdf.Bookmark(category.Name, 0, -1)
+	r.section = category.Name
+	r.sectionColor = category.Color
+	r.testProgress = ""
+	r.coloredHeading(1, category.Name, category.Color)
+	passed, total := 0, 0
+	for _, group := range category.Groups {
+		for _, test := range group.Tests {
+			total++
+			if strings.HasPrefix(strings.ToLower(test.Execution.Status), "pass") {
+				passed++
+			}
+		}
+	}
+	r.paragraph(fmt.Sprintf("%d over %d tests passed", passed, total))
+	for _, group := range category.Groups {
+		r.renderSubgroup(group, category.Name, category.Color)
+	}
+}
+
+func (r *renderer) renderSubgroup(group TestGroup, categoryName string, color [3]int) {
+	r.pdf.AddPage()
+	r.section = categoryName + " · " + group.Name
+	r.sectionColor = color
+	r.testProgress = ""
+	r.coloredHeading(2, group.Name, color)
 	passed := 0
 	for _, test := range group.Tests {
 		if strings.HasPrefix(strings.ToLower(test.Execution.Status), "pass") {
@@ -283,23 +446,26 @@ func (r *renderer) renderGroup(group TestGroup) {
 }
 
 func (r *renderer) renderTest(test TestEntry) {
-	r.pdf.SetFont("SourceCodePro", "", 7.5)
-	wrappedID := r.wrapToken(test.Execution.TestID, bodyWidth-44)
-	idLines := strings.Count(wrappedID, "\n") + 1
-	cardHeight := 10.0 + 4.5*float64(idLines) + 3.0
-	r.ensureSpace(cardHeight + 6)
+	r.pdf.AddPage()
+	r.testCount++
+	r.testProgress = fmt.Sprintf("Test %d of %d", r.testCount, r.document.SelectedCount)
 	r.pdf.Bookmark(test.Execution.TestID, 1, -1)
-	cardY := r.pdf.GetY()
-	r.pdf.SetFillColor(248, 247, 252)
-	r.pdf.SetDrawColor(225, 222, 237)
-	r.pdf.RoundedRect(pageMargin, cardY, bodyWidth, cardHeight, 2, "1234", "DF")
-	r.pdf.SetXY(pageMargin+6, cardY+4)
-	r.pdf.SetFont("SourceCodePro", "", 7.5)
-	r.pdf.SetTextColor(75, 72, 90)
-	r.pdf.MultiCell(bodyWidth-44, 4.5, wrappedID, "", "L", false)
-	r.pdf.SetXY(pageWidth-pageMargin-27, cardY+4)
+
+	title := firstNonEmpty(test.Execution.Title, test.Execution.TestID)
+	r.pdf.SetFont("Inter", "B", 12)
+	r.pdf.SetTextColor(41, 18, 120)
+	titleY := r.pdf.GetY()
+	r.pdf.SetXY(pageMargin, titleY)
+	r.pdf.MultiCell(bodyWidth-32, 6, r.wrapToken(title, bodyWidth-32), "", "L", false)
+	titleBottom := r.pdf.GetY()
+	r.pdf.SetXY(pageWidth-pageMargin-27, titleY+1)
 	r.statusCell(test.Execution.Status, 23)
-	r.pdf.SetXY(pageMargin, cardY+cardHeight+3)
+
+	r.pdf.SetXY(pageMargin, max(titleBottom, titleY+8)+1)
+	r.pdf.SetFont("SourceCodePro", "", 7.5)
+	r.pdf.SetTextColor(100, 98, 112)
+	r.pdf.MultiCell(bodyWidth, 4.5, r.wrapToken(test.Execution.TestID, bodyWidth), "", "L", false)
+	r.pdf.Ln(4)
 
 	if test.Execution.Outcome.Reason != "" {
 		r.labelledText("Outcome", test.Execution.Outcome.Reason)
@@ -396,9 +562,7 @@ func (r *renderer) renderTest(test TestEntry) {
 	}
 	if len(test.Images) > 0 {
 		r.heading(3, "Visual evidence:")
-		for _, image := range test.Images {
-			r.renderImage(image)
-		}
+		r.renderImageGrid(test.Images)
 	}
 	r.pdf.Ln(5)
 }
@@ -470,9 +634,9 @@ func (r *renderer) renderWarnings() {
 	}
 }
 
-func (r *renderer) renderImage(image ImageAsset) {
+func (r *renderer) registerImage(image ImageAsset) (string, float64, float64, bool) {
 	if len(image.Data) == 0 {
-		return
+		return "", 0, 0, false
 	}
 	registeredName, found := r.registeredImages[image.Filename]
 	if !found {
@@ -483,15 +647,26 @@ func (r *renderer) renderImage(image ImageAsset) {
 			bytes.NewReader(image.Data),
 		)
 		if r.pdf.Error() != nil {
-			return
+			return "", 0, 0, false
 		}
 		r.registeredImages[image.Filename] = registeredName
 	}
 	info := r.pdf.GetImageInfo(registeredName)
 	if info == nil {
-		return
+		return "", 0, 0, false
 	}
 	width, height := info.Extent()
+	if width <= 0 || height <= 0 {
+		return "", 0, 0, false
+	}
+	return registeredName, width, height, true
+}
+
+func (r *renderer) renderImage(image ImageAsset) {
+	name, width, height, ok := r.registerImage(image)
+	if !ok {
+		return
+	}
 	maxWidth, maxHeight := 120.0, 92.0
 	if width > maxWidth {
 		height *= maxWidth / width
@@ -503,17 +678,7 @@ func (r *renderer) renderImage(image ImageAsset) {
 	}
 	r.ensureSpace(height + 11)
 	x := pageMargin + (bodyWidth-width)/2
-	r.pdf.ImageOptions(
-		registeredName,
-		x,
-		r.pdf.GetY(),
-		width,
-		height,
-		false,
-		fpdf.ImageOptions{ImageType: "PNG"},
-		0,
-		"",
-	)
+	r.pdf.ImageOptions(name, x, r.pdf.GetY(), width, height, false, fpdf.ImageOptions{ImageType: "PNG"}, 0, "")
 	r.pdf.SetY(r.pdf.GetY() + height + 1.5)
 	r.pdf.SetFont("SourceCodePro", "", 7)
 	r.pdf.SetTextColor(100, 98, 112)
@@ -522,6 +687,74 @@ func (r *renderer) renderImage(image ImageAsset) {
 		caption += " · " + image.EvidenceKey
 	}
 	r.pdf.MultiCell(bodyWidth, 4, caption, "", "C", false)
+	r.pdf.Ln(2)
+}
+
+func (r *renderer) renderImageGrid(images []ImageAsset) {
+	const columns = 2
+	const gap = 8.0
+	const captionHeight = 10.0
+	const maxImageHeight = 110.0
+
+	cellWidth := (bodyWidth - float64(columns-1)*gap) / columns
+	rowY := 0.0
+
+	type figure struct {
+		number      int
+		filename    string
+		evidenceKey string
+	}
+	figures := make([]figure, 0, len(images))
+
+	for i, image := range images {
+		col := i % columns
+		if col == 0 {
+			r.ensureSpace(maxImageHeight + captionHeight + 8)
+			rowY = r.pdf.GetY()
+		}
+
+		name, width, height, ok := r.registerImage(image)
+		if !ok {
+			continue
+		}
+		scale := min(cellWidth/width, maxImageHeight/height)
+		drawW := width * scale
+		drawH := height * scale
+
+		r.evidenceCount++
+		figures = append(figures, figure{
+			number:      r.evidenceCount,
+			filename:    image.Filename,
+			evidenceKey: image.EvidenceKey,
+		})
+
+		x := pageMargin + float64(col)*(cellWidth+gap) + (cellWidth-drawW)/2
+		r.pdf.ImageOptions(name, x, rowY, drawW, drawH, false, fpdf.ImageOptions{ImageType: "PNG"}, 0, "")
+
+		r.pdf.SetXY(pageMargin+float64(col)*(cellWidth+gap), rowY+maxImageHeight+1.5)
+		r.pdf.SetFont("SourceCodePro", "", 7)
+		r.pdf.SetTextColor(100, 98, 112)
+		r.pdf.CellFormat(cellWidth, 3.5, fmt.Sprintf("Evidence %d", r.evidenceCount), "", 0, "C", false, 0, "")
+
+		if col == columns-1 {
+			r.pdf.SetY(rowY + maxImageHeight + captionHeight + 3)
+		}
+	}
+
+	// Contextual table of pictures: full filenames, untruncated, right after the grid.
+	for _, fig := range figures {
+		r.ensureSpace(8)
+		r.pdf.SetFont("Inter", "M", 8)
+		r.pdf.SetTextColor(40, 38, 48)
+		r.pdf.CellFormat(24, 4.5, fmt.Sprintf("Evidence %d:", fig.number), "", 0, "L", false, 0, "")
+		name := fig.filename
+		if fig.evidenceKey != "" {
+			name += " · " + fig.evidenceKey
+		}
+		r.pdf.SetFont("SourceCodePro", "", 7)
+		r.pdf.SetTextColor(75, 72, 90)
+		r.pdf.MultiCell(bodyWidth-24, 4.5, r.wrapToken(name, bodyWidth-24), "", "L", false)
+	}
 	r.pdf.Ln(2)
 }
 
@@ -553,6 +786,49 @@ func (r *renderer) heading(level int, text string) {
 	r.pdf.SetTextColor(41, 18, 120)
 	r.pdf.MultiCell(bodyWidth, spaces[level], r.wrapToken(text, bodyWidth), "", "L", false)
 	r.pdf.Ln(1)
+}
+
+func (r *renderer) coloredHeading(level int, text string, color [3]int) {
+	sizes := map[int]float64{1: 15, 2: 10.5}
+	spaces := map[int]float64{1: 8, 2: 6}
+	r.ensureSpace(spaces[level] + 8)
+	r.pdf.Ln(spaces[level] / 2)
+	y := r.pdf.GetY()
+	r.pdf.SetFillColor(color[0], color[1], color[2])
+	r.pdf.Rect(pageMargin, y, 3.5, sizes[level]+3, "F")
+	r.pdf.SetXY(pageMargin+11, y)
+	r.pdf.SetFont("Inter", "B", sizes[level])
+	r.pdf.SetTextColor(color[0], color[1], color[2])
+	r.pdf.MultiCell(bodyWidth-11, spaces[level], r.wrapToken(text, bodyWidth-11), "", "L", false)
+	r.pdf.SetY(max(r.pdf.GetY(), y+sizes[level]+3))
+	r.pdf.Ln(1)
+}
+
+func (r *renderer) colorSwatch(color [3]int, label string) {
+	r.ensureSpace(8)
+	y := r.pdf.GetY()
+	r.pdf.SetFillColor(color[0], color[1], color[2])
+	r.pdf.Rect(pageMargin, y+1, 6, 6, "F")
+	r.pdf.SetXY(pageMargin+10, y)
+	r.pdf.SetFont("Inter", "", 9)
+	r.pdf.SetTextColor(40, 38, 48)
+	r.pdf.CellFormat(bodyWidth-10, 7, label, "", 0, "L", false, 0, "")
+	r.pdf.Ln(8)
+}
+
+func (r *renderer) summaryRow(label string, passed, total int, color [3]int) {
+	r.ensureSpace(7)
+	y := r.pdf.GetY()
+	r.pdf.SetFillColor(color[0], color[1], color[2])
+	r.pdf.Rect(pageMargin+18, y+1.5, 2.5, 4.5, "F")
+	r.pdf.SetXY(pageMargin+26, y)
+	r.pdf.SetFont("Inter", "", 9)
+	r.pdf.SetTextColor(40, 38, 48)
+	r.pdf.CellFormat(bodyWidth-78, 6, label, "", 0, "L", false, 0, "")
+	r.pdf.SetFont("SourceCodePro", "", 8.5)
+	r.pdf.SetTextColor(75, 72, 90)
+	r.pdf.CellFormat(52, 6, fmt.Sprintf("%d/%d passed", passed, total), "", 0, "R", false, 0, "")
+	r.pdf.Ln(7)
 }
 
 func (r *renderer) paragraph(text string) {

--- a/pkg/fcaf/reportpdf/reportpdf_test.go
+++ b/pkg/fcaf/reportpdf/reportpdf_test.go
@@ -95,9 +95,9 @@ func TestBuildDocumentAssociatesOnlyExactEvidenceImages(t *testing.T) {
 		},
 	})
 
-	require.Len(t, document.Groups, 1)
-	require.Len(t, document.Groups[0].Tests[0].Images, 1)
-	require.Empty(t, document.Groups[0].Tests[1].Images)
+	require.Len(t, document.Categories, 1)
+	require.Len(t, document.Categories[0].Groups[0].Tests[0].Images, 1)
+	require.Empty(t, document.Categories[0].Groups[0].Tests[1].Images)
 	require.Len(t, document.Unassigned, 1)
 	require.NotEmpty(t, document.JSONSHA256)
 }
@@ -128,10 +128,12 @@ func TestBuildDocumentFallsBackToFilenameAssociation(t *testing.T) {
 		},
 	})
 
-	require.Len(t, document.Groups, 2)
+	require.Len(t, document.Categories, 1)
+	require.Len(t, document.Categories[0].Groups, 2)
+	// Subgroups sort alphabetically: AddressData before Credentialmetadata.
+	require.Empty(t, document.Categories[0].Groups[0].Tests[0].Images)
 	// "credential" word overlaps the Credentialmetadata test id.
-	require.Len(t, document.Groups[0].Tests[0].Images, 1)
-	require.Empty(t, document.Groups[1].Tests[0].Images)
+	require.Len(t, document.Categories[0].Groups[1].Tests[0].Images, 1)
 	require.Len(t, document.Unassigned, 1)
 }
 

--- a/pkg/internal/apis/handlers/pipeline_fcaf_pdf.go
+++ b/pkg/internal/apis/handlers/pipeline_fcaf_pdf.go
@@ -15,6 +15,7 @@ import (
 	"github.com/forkbombeu/credimi/pkg/fcaf/engine"
 	"github.com/forkbombeu/credimi/pkg/fcaf/reportpdf"
 	"github.com/forkbombeu/credimi/pkg/internal/canonify"
+	"github.com/forkbombeu/credimi/pkg/internal/pipeline"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -208,6 +209,7 @@ func pipelineFCAFReportMetadata(
 			} else {
 				metadata.PipelineIdentifier = strings.Trim(identifier, "/")
 			}
+			metadata.Runner = resolvePipelineRunner(app, pipelineRecord)
 		}
 	}
 
@@ -243,4 +245,35 @@ func firstNonBlank(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func resolvePipelineRunner(app core.App, pipelineRecord *core.Record) reportpdf.RunnerInfo {
+	wf, err := pipeline.ParseWorkflow(pipelineRecord.GetString("yaml"))
+	if err != nil || wf.Runtime.GlobalRunnerID == "" {
+		return reportpdf.RunnerInfo{}
+	}
+	runnerRecord, err := canonify.Resolve(app, canonify.NormalizePath(wf.Runtime.GlobalRunnerID))
+	if err != nil {
+		return reportpdf.RunnerInfo{}
+	}
+	return reportpdf.RunnerInfo{
+		Name:   runnerRecord.GetString("name"),
+		Type:   humanizeRunnerType(runnerRecord.GetString("type")),
+		Serial: runnerRecord.GetString("serial"),
+	}
+}
+
+func humanizeRunnerType(runnerType string) string {
+	switch runnerType {
+	case "android_emulator":
+		return "Android emulator"
+	case "android_phone":
+		return "Android phone"
+	case "ios_emulator", "ios_simulator":
+		return "iOS simulator"
+	case "ios_phone":
+		return "iOS phone"
+	default:
+		return runnerType
+	}
 }

--- a/webapp/src/lib/fcaf/categories.test.ts
+++ b/webapp/src/lib/fcaf/categories.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import { parseFCAFTestId } from './categories';
+
+describe('parseFCAFTestId', () => {
+	it('maps DM identifiers to the data model category', () => {
+		const { category, key, label } = parseFCAFTestId(
+			'WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_001'
+		);
+		expect(category.code).toBe('DM');
+		expect(category.label).toBe('Data model');
+		expect(key).toBe('addressdata');
+		expect(label).toBe('Address data');
+	});
+
+	it('handles double-underscore interaction identifiers', () => {
+		const { category, label } = parseFCAFTestId('WS_RP_IA_MainInteraction__003');
+		expect(category.code).toBe('IA');
+		expect(label).toBe('Main interaction');
+	});
+
+	it('normalizes credential metadata casing variants', () => {
+		expect(parseFCAFTestId('WS_RP_DM_Credentialmetadata_X_001').label).toBe(
+			'Credential metadata'
+		);
+		expect(parseFCAFTestId('WS_RP_DM_CredentialMetadata_X_001').label).toBe(
+			'Credential metadata'
+		);
+	});
+
+	it('maps RpIntegrity to the RP integrity label', () => {
+		expect(parseFCAFTestId('WS_RP_SM_RpIntegrity_ABC_001').label).toBe('RP integrity');
+	});
+
+	it('falls back to Other for unknown prefixes', () => {
+		const { category, label } = parseFCAFTestId('SOMETHING_ELSE');
+		expect(category.code).toBe('OTHER');
+		expect(label).toBe('Other');
+	});
+
+	it('falls back to Other for missing identifiers', () => {
+		expect(parseFCAFTestId(undefined).category.code).toBe('OTHER');
+		expect(parseFCAFTestId('').category.code).toBe('OTHER');
+	});
+});

--- a/webapp/src/lib/fcaf/categories.ts
+++ b/webapp/src/lib/fcaf/categories.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Canonical FCAF wallet-solution/relying-party grouping.
+ *
+ * Test identifiers encode their owning FCAF section and subsection directly:
+ *
+ *   WS_RP_<CATEGORY>_<SUBGROUP>_<specifics>_<NNN>
+ *
+ * e.g. `WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_001`
+ *      `WS_RP_IA_MainInteraction__003`
+ *
+ * `suite.section` in the test YAML is not reliable here: some entries carry the
+ * semantic dotted path (`data_model.address_data`) while others carry ARF
+ * clause references (`"6.1"`, `"3"`). The identifier prefix is stable across
+ * every test, so it is the source of truth for grouping the report.
+ */
+
+export type FCAFCategoryCode = 'DM' | 'MS' | 'IA' | 'SM' | 'SH' | 'UC' | 'OTHER';
+
+export type FCAFCategory = {
+	code: FCAFCategoryCode;
+	label: string;
+	// Static Tailwind classes backed by the --fcaf-* tokens in layout.css.
+	// Kept as literal strings so Tailwind's content scanner emits them.
+	text: string;
+	bar: string;
+	railBg: string;
+	railBorder: string;
+};
+
+const CATEGORIES: Record<FCAFCategoryCode, FCAFCategory> = {
+	DM: {
+		code: 'DM',
+		label: 'Data model',
+		text: 'text-fcaf-data-model',
+		bar: 'bg-fcaf-data-model',
+		railBg: 'bg-fcaf-data-model/10',
+		railBorder: 'border-fcaf-data-model'
+	},
+	MS: {
+		code: 'MS',
+		label: 'Message structure',
+		text: 'text-fcaf-message-structure',
+		bar: 'bg-fcaf-message-structure',
+		railBg: 'bg-fcaf-message-structure/10',
+		railBorder: 'border-fcaf-message-structure'
+	},
+	IA: {
+		code: 'IA',
+		label: 'Interaction',
+		text: 'text-fcaf-interaction',
+		bar: 'bg-fcaf-interaction',
+		railBg: 'bg-fcaf-interaction/10',
+		railBorder: 'border-fcaf-interaction'
+	},
+	SM: {
+		code: 'SM',
+		label: 'Security mechanisms',
+		text: 'text-fcaf-security-mechanisms',
+		bar: 'bg-fcaf-security-mechanisms',
+		railBg: 'bg-fcaf-security-mechanisms/10',
+		railBorder: 'border-fcaf-security-mechanisms'
+	},
+	SH: {
+		code: 'SH',
+		label: 'Shared',
+		text: 'text-fcaf-shared',
+		bar: 'bg-fcaf-shared',
+		railBg: 'bg-fcaf-shared/10',
+		railBorder: 'border-fcaf-shared'
+	},
+	UC: {
+		code: 'UC',
+		label: 'Use cases',
+		text: 'text-fcaf-use-cases',
+		bar: 'bg-fcaf-use-cases',
+		railBg: 'bg-fcaf-use-cases/10',
+		railBorder: 'border-fcaf-use-cases'
+	},
+	OTHER: {
+		code: 'OTHER',
+		label: 'Other',
+		text: 'text-muted-foreground',
+		bar: 'bg-muted-foreground',
+		railBg: 'bg-muted/20',
+		railBorder: 'border-muted-foreground/50'
+	}
+};
+
+/** Display order for the report body. */
+export const FCAF_CATEGORY_ORDER: FCAFCategoryCode[] = [
+	'DM',
+	'MS',
+	'IA',
+	'SM',
+	'SH',
+	'UC',
+	'OTHER'
+];
+
+const SUBGROUP_LABELS: Record<string, string> = {
+	addressdata: 'Address data',
+	identifyingdata: 'Identifying data',
+	credentialmetadata: 'Credential metadata',
+	protocolmessages: 'Protocol messages',
+	metadata: 'Metadata',
+	credentialformats: 'Credential formats',
+	maininteraction: 'Main interaction',
+	engagement: 'Engagement',
+	protocolflow: 'Protocol flow',
+	supportive: 'Supportive',
+	rpintegrity: 'RP integrity',
+	trustmechanisms: 'Trust mechanisms',
+	sessionencryption: 'Session encryption',
+	devicebinding: 'Device binding',
+	sessionbinding: 'Session binding',
+	issuerintegrity: 'Issuer integrity',
+	encoding: 'Encoding',
+	cryptography: 'Cryptography',
+	presentation: 'Presentation'
+};
+
+export type ParsedFCAFTestId = {
+	category: FCAFCategory;
+	/** Normalized subgroup key (lowercased segment), used as a stable map/loop key. */
+	key: string;
+	/** Human-readable subgroup label. */
+	label: string;
+};
+
+export function subgroupLabel(segment: string): string {
+	return SUBGROUP_LABELS[segment.toLowerCase()] ?? humanize(segment);
+}
+
+export function parseFCAFTestId(testId: string | undefined): ParsedFCAFTestId {
+	if (!testId) return { category: CATEGORIES.OTHER, key: 'other', label: 'Other' };
+
+	const parts = testId.split('_');
+	// WS_RP_<CATEGORY>_<SUBGROUP>_...
+	if (parts.length >= 4 && parts[0] === 'WS' && parts[1] === 'RP') {
+		const code = parts[2].toUpperCase() as FCAFCategoryCode;
+		const category = CATEGORIES[code] ?? CATEGORIES.OTHER;
+		const segment = parts[3];
+		return { category, key: segment.toLowerCase(), label: subgroupLabel(segment) };
+	}
+
+	return { category: CATEGORIES.OTHER, key: 'other', label: 'Other' };
+}
+
+function humanize(segment: string): string {
+	const words = segment.replace(/([a-z0-9])([A-Z])/g, '$1 $2').split(' ');
+	return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+}

--- a/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
+++ b/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
@@ -7,8 +7,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
-	import { DownloadIcon, ExternalLinkIcon } from '@lucide/svelte';
+	import { ChevronRightIcon, DownloadIcon, ExternalLinkIcon, SearchIcon } from '@lucide/svelte';
 	import LazyImage from '$lib/components/lazy-image.svelte';
+	import {
+		FCAF_CATEGORY_ORDER,
+		parseFCAFTestId,
+		type FCAFCategory
+	} from '$lib/fcaf/categories.js';
 	import CodeDisplay from '$lib/layout/codeDisplay.svelte';
 	import { activeSheet } from '$lib/utils/sheet-state.svelte';
 	import { SvelteSet } from 'svelte/reactivity';
@@ -137,15 +142,99 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		return undefined;
 	}
 
-	function icsFromTestId(testId: string | undefined): string {
-		if (!testId) return 'Other';
-		const match = testId.match(/^(.+)__\d+$/);
-		return match ? match[1] : testId;
+	type CategoryGroup = {
+		category: FCAFCategory;
+		passed: number;
+		total: number;
+		groups: GroupedGroup[];
+	};
+
+	type GroupedGroup = {
+		key: string;
+		label: string;
+		passed: number;
+		total: number;
+		rate: number;
+		tests: TestResult[];
+	};
+
+	function groupExecutedTests(tests: TestResult[]): CategoryGroup[] {
+		const byCategory = new Map<
+			string,
+			{ category: FCAFCategory; groups: Map<string, { label: string; tests: TestResult[] }> }
+		>();
+		for (const test of tests) {
+			const parsed = parseFCAFTestId(test.test_id);
+			let entry = byCategory.get(parsed.category.code);
+			if (!entry) {
+				entry = { category: parsed.category, groups: new Map() };
+				byCategory.set(parsed.category.code, entry);
+			}
+			const bucket = entry.groups.get(parsed.key);
+			if (bucket) {
+				bucket.tests.push(test);
+			} else {
+				entry.groups.set(parsed.key, { label: parsed.label, tests: [test] });
+			}
+		}
+		return FCAF_CATEGORY_ORDER.filter((code) => byCategory.has(code)).map((code) => {
+			const entry = byCategory.get(code)!;
+			const groups: GroupedGroup[] = [...entry.groups.entries()]
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([key, { label, tests: groupTests }]) => {
+					const passed = groupTests.filter((t) => statusIsPassed(t.status)).length;
+					const total = groupTests.length;
+					return {
+						key,
+						label,
+						passed,
+						total,
+						rate: total > 0 ? Math.round((passed / total) * 100) : 0,
+						tests: groupTests
+					};
+				});
+			return {
+				category: entry.category,
+				passed: groups.reduce((sum, group) => sum + group.passed, 0),
+				total: groups.reduce((sum, group) => sum + group.total, 0),
+				groups
+			};
+		});
+	}
+
+	function testMatchesSearch(test: TestResult, query: string): boolean {
+		const parsed = parseFCAFTestId(test.test_id);
+		const haystack =
+			`${test.test_id ?? ''} ${test.title ?? ''} ${parsed.category.label} ${parsed.label}`.toLowerCase();
+		return haystack.includes(query);
 	}
 
 	let { reportUrl, pdfUrl, maestroScreenshotUrls, sheetTrigger }: Props = $props();
 	let selectedFilter = $state<string>('all');
+	let search = $state('');
+	let openGroups = $state<Record<string, boolean>>({});
 	let sheetOpen = $state(false);
+
+	const searchQuery = $derived(search.trim().toLowerCase());
+	const searching = $derived(searchQuery !== '');
+
+	function isOpen(key: string): boolean {
+		return searching || (openGroups[key] ?? false);
+	}
+
+	function toggleOpen(key: string) {
+		openGroups[key] = !(openGroups[key] ?? false);
+	}
+
+	function expandAll(categories: CategoryGroup[]) {
+		for (const category of categories) {
+			for (const group of category.groups) openGroups[group.key] = true;
+		}
+	}
+
+	function collapseAll() {
+		openGroups = {};
+	}
 
 	$effect(() => {
 		if (sheetOpen) {
@@ -220,6 +309,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 							allScreenshots,
 							executedTests
 						)}
+						{@const filteredTests = executedTests.filter(
+							(t) =>
+								(selectedFilter === 'all' ||
+									(t.status ?? '').startsWith(selectedFilter)) &&
+								testMatchesSearch(t, searchQuery)
+						)}
+						{@const groupedCategories = groupExecutedTests(filteredTests)}
 
 						<div
 							class="sticky top-0 z-20 -mx-6 border-b bg-background/95 px-6 py-3 backdrop-blur"
@@ -319,149 +415,224 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									{/each}
 								</div>
 							{/if}
+							<div class="mt-3 flex flex-wrap items-center gap-2">
+								<div class="relative min-w-0 grow sm:max-w-xs">
+									<SearchIcon
+										class="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground"
+										aria-hidden="true"
+									/>
+									<input
+										type="search"
+										bind:value={search}
+										placeholder="Search tests"
+										aria-label="Search tests"
+										class="h-8 w-full rounded-md border bg-background pr-2 pl-7 text-sm placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+									/>
+								</div>
+								<div class="ml-auto flex items-center gap-1">
+									<button
+										type="button"
+										class="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+										onclick={() => expandAll(groupedCategories)}
+									>
+										Expand all
+									</button>
+									<button
+										type="button"
+										class="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+										onclick={collapseAll}
+									>
+										Collapse all
+									</button>
+								</div>
+							</div>
+
+							<div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+								{#each groupedCategories as category (category.category.code)}
+									<a
+										href="#fcaf-category-{category.category.code}"
+										class="inline-flex items-center gap-1.5 rounded-full border bg-background px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted"
+									>
+										<span
+											class="inline-block size-2 rounded-full {category
+												.category.bar}"
+											aria-hidden="true"
+										></span>
+										<span class="font-medium {category.category.text}"
+											>{category.category.label}</span
+										>
+										<span class="text-muted-foreground"
+											>{category.passed}/{category.total}</span
+										>
+									</a>
+								{/each}
+							</div>
 						</div>
 
-						{@const filteredTests = executedTests.filter(
-							(t) =>
-								selectedFilter === 'all' ||
-								(t.status ?? '').startsWith(selectedFilter)
-						)}
-						{@const grouped = filteredTests.reduce(
-							(acc, t) => {
-								const key = icsFromTestId(t.test_id);
-								(acc[key] ??= []).push(t);
-								return acc;
-							},
-							{} as Record<string, TestResult[]>
-						)}
-						<div class="space-y-6 pt-4">
-							{#each Object.entries(grouped) as [ics, tests] (ics)}
-								{@const icsPassed = (tests ?? []).filter((t) =>
-									statusIsPassed(t.status)
-								).length}
-								{@const icsTotal = (tests ?? []).length}
-								{@const icsRate =
-									icsTotal > 0 ? Math.round((icsPassed / icsTotal) * 100) : 0}
-								<section>
-									<div class="mb-2 flex items-baseline gap-2">
-										<h3 class="font-mono text-sm font-semibold break-all">
-											{ics}
-										</h3>
-										<span class="text-xs text-muted-foreground">
-											{icsPassed}/{icsTotal} passed
+						{#snippet testCard(test: TestResult, testScreenshots: Screenshot[])}
+							<div class="rounded border p-4">
+								<div class="flex items-start justify-between gap-4">
+									<div class="min-w-0">
+										<div class="font-medium">
+											{test.title ?? test.test_id}
+										</div>
+										{#if fcafSourceUrl(test.test_id)}
+											<a
+												href={fcafSourceUrl(test.test_id)}
+												target="_blank"
+												rel="noreferrer"
+												class="inline-flex items-center gap-1 text-xs text-primary underline underline-offset-2"
+											>
+												<code>{test.test_id}</code>
+												<ExternalLinkIcon class="size-3" />
+											</a>
+										{:else}
+											<code class="text-xs text-muted-foreground"
+												>{test.test_id}</code
+											>
+										{/if}
+									</div>
+									<span
+										class="inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium {statusClass(
+											test.status
+										)}"
+									>
+										<span
+											class="inline-block size-1.5 rounded-full {statusDotClass(
+												test.status
+											)}"
+											aria-hidden="true"
+										></span>
+										{test.status ?? 'unknown'}
+									</span>
+								</div>
+								{#if test.assertions?.length || test.validators?.length}
+									<div class="mt-3 space-y-2 border-t pt-3 text-sm">
+										{#each test.validators ?? test.assertions ?? [] as validator (validator.id)}
+											<div class="flex justify-between gap-3">
+												<span>{validator.validator ?? validator.id}</span>
+												<strong class={statusClass(validator.status)}
+													>{validator.status ?? 'unknown'}</strong
+												>
+											</div>
+											{#if validator.message}
+												<div class="text-xs text-muted-foreground">
+													{validator.message}
+												</div>
+											{/if}
+										{/each}
+									</div>
+								{/if}
+								{#if testScreenshots.length}
+									<div class="mt-4 space-y-2 border-t pt-3">
+										<div
+											class="text-xs font-medium tracking-wide text-muted-foreground uppercase"
+										>
+											Visual evidence
+										</div>
+										<div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+											{#each testScreenshots as screenshot (screenshot.url)}
+												<a
+													href={screenshot.url}
+													target="_blank"
+													rel="noreferrer"
+													class="block overflow-hidden rounded border bg-muted/20"
+												>
+													<LazyImage
+														src={screenshot.url}
+														alt={screenshot.label}
+														class="aspect-video h-auto w-full object-contain"
+													/>
+													<div
+														class="px-2 py-1 text-xs break-all text-muted-foreground"
+													>
+														{screenshot.label}
+													</div>
+												</a>
+											{/each}
+										</div>
+									</div>
+								{/if}
+							</div>
+						{/snippet}
+
+						<div class="space-y-4 pt-4">
+							{#each groupedCategories as category (category.category.code)}
+								<section
+									id="fcaf-category-{category.category.code}"
+									class="grid grid-cols-[auto_1fr] overflow-hidden rounded-lg border"
+								>
+									<div
+										class="flex w-9 flex-col items-center gap-2 border-r py-3 {category
+											.category.railBg}"
+									>
+										<span
+											class="rotate-180 py-2 font-mono text-[11px] font-semibold tracking-[0.14em] uppercase [writing-mode:vertical-rl] {category
+												.category.text}"
+										>
+											{category.category.label}
+										</span>
+										<span
+											class="mt-auto font-mono text-[10px] {category.category
+												.text}"
+										>
+											{category.passed}/{category.total}
 										</span>
 									</div>
-									<div class="mb-3 h-1 overflow-hidden rounded-full bg-muted">
-										<div
-											class="h-full rounded-full {icsTotal > 0
-												? icsPassed === icsTotal
-													? 'bg-green-600'
-													: icsPassed > 0
-														? 'bg-amber-500'
-														: 'bg-red-600'
-												: 'bg-muted'}"
-											style="width: {icsRate}%"
-										></div>
-									</div>
-									<div class="space-y-3">
-										{#each tests ?? [] as test (test.test_id)}
-											{@const testScreenshots = screenshotsForTest(
-												allScreenshots,
-												test
-											)}
-											<div class="rounded border p-4">
-												<div class="flex items-start justify-between gap-4">
-													<div class="min-w-0">
-														<div class="font-medium">
-															{test.title ?? test.test_id}
-														</div>
-														{#if fcafSourceUrl(test.test_id)}
-															<a
-																href={fcafSourceUrl(test.test_id)}
-																target="_blank"
-																rel="noreferrer"
-																class="inline-flex items-center gap-1 text-xs text-primary underline underline-offset-2"
-															>
-																<code>{test.test_id}</code>
-																<ExternalLinkIcon class="size-3" />
-															</a>
-														{:else}
-															<code
-																class="text-xs text-muted-foreground"
-																>{test.test_id}</code
-															>
-														{/if}
-													</div>
-													<span
-														class="inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium {statusClass(
-															test.status
-														)}"
+
+									<div class="min-w-0 divide-y">
+										{#each category.groups as group (group.key)}
+											<div class="px-4 py-3">
+												<div class="flex items-center gap-2">
+													<button
+														type="button"
+														class="flex min-w-0 items-center gap-1.5 text-left"
+														aria-expanded={isOpen(group.key)}
+														onclick={() => toggleOpen(group.key)}
 													>
-														<span
-															class="inline-block size-1.5 rounded-full {statusDotClass(
-																test.status
-															)}"
+														<ChevronRightIcon
+															class="size-4 shrink-0 text-muted-foreground transition-transform {isOpen(
+																group.key
+															)
+																? 'rotate-90'
+																: ''}"
 															aria-hidden="true"
-														></span>
-														{test.status ?? 'unknown'}
-													</span>
-												</div>
-												{#if test.assertions?.length || test.validators?.length}
-													<div
-														class="mt-3 space-y-2 border-t pt-3 text-sm"
+														/>
+														<span class="truncate text-sm font-medium"
+															>{group.label}</span
+														>
+													</button>
+													<span class="text-xs text-muted-foreground"
+														>{group.passed}/{group.total} passed</span
 													>
-														{#each test.validators ?? test.assertions ?? [] as validator (validator.id)}
-															<div class="flex justify-between gap-3">
-																<span
-																	>{validator.validator ??
-																		validator.id}</span
-																>
-																<strong
-																	class={statusClass(
-																		validator.status
-																	)}
-																	>{validator.status ??
-																		'unknown'}</strong
-																>
-															</div>
-															{#if validator.message}<div
-																	class="text-xs text-muted-foreground"
-																>
-																	{validator.message}
-																</div>{/if}
+													<span
+														class="ml-auto shrink-0 text-xs text-muted-foreground"
+														>{group.total}
+														{group.total === 1 ? 'test' : 'tests'}</span
+													>
+												</div>
+												<div
+													class="mt-2 h-1 overflow-hidden rounded-full bg-muted"
+												>
+													<div
+														class="h-full rounded-full {group.rate > 0
+															? category.category.bar
+															: 'bg-muted'}"
+														style="width: {group.rate}%"
+													></div>
+												</div>
+
+												{#if isOpen(group.key)}
+													<div class="mt-3 space-y-3 pl-5">
+														{#each group.tests as test (test.test_id)}
+															{@render testCard(
+																test,
+																screenshotsForTest(
+																	allScreenshots,
+																	test
+																)
+															)}
 														{/each}
-													</div>
-												{/if}
-												{#if testScreenshots.length}
-													<div class="mt-4 space-y-2 border-t pt-3">
-														<div
-															class="text-xs font-medium tracking-wide text-muted-foreground uppercase"
-														>
-															Visual evidence
-														</div>
-														<div
-															class="grid grid-cols-2 gap-2 sm:grid-cols-4"
-														>
-															{#each testScreenshots as screenshot (screenshot.url)}
-																<a
-																	href={screenshot.url}
-																	target="_blank"
-																	rel="noreferrer"
-																	class="block overflow-hidden rounded border bg-muted/20"
-																>
-																	<LazyImage
-																		src={screenshot.url}
-																		alt={screenshot.label}
-																		class="aspect-video h-auto w-full object-contain"
-																	/>
-																	<div
-																		class="px-2 py-1 text-xs break-all text-muted-foreground"
-																	>
-																		{screenshot.label}
-																	</div>
-																</a>
-															{/each}
-														</div>
 													</div>
 												{/if}
 											</div>
@@ -469,6 +640,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									</div>
 								</section>
 							{/each}
+
+							{#if filteredTests.length === 0 && totalTests > 0}
+								<p class="py-8 text-center text-sm text-muted-foreground">
+									No tests match the current filter.
+								</p>
+							{/if}
 						</div>
 
 						{#if unassignedScreenshots.length}

--- a/webapp/src/routes/layout.css
+++ b/webapp/src/routes/layout.css
@@ -38,6 +38,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	--chart-3: oklch(0.398 0.07 227.392);
 	--chart-4: oklch(0.828 0.189 84.429);
 	--chart-5: oklch(0.769 0.188 70.08);
+	--fcaf-data-model: oklch(0.5 0.17 262);
+	--fcaf-message-structure: oklch(0.52 0.13 200);
+	--fcaf-interaction: oklch(0.54 0.17 45);
+	--fcaf-security-mechanisms: oklch(0.5 0.2 330);
+	--fcaf-shared: oklch(0.5 0.13 155);
+	--fcaf-use-cases: oklch(0.58 0.15 85);
 	--sidebar: oklch(0.984 0.003 247.858);
 	--sidebar-foreground: oklch(0.129 0.042 264.695);
 	--sidebar-primary: oklch(0.208 0.042 265.755);
@@ -72,6 +78,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	--chart-3: oklch(0.769 0.188 70.08);
 	--chart-4: oklch(0.627 0.265 303.9);
 	--chart-5: oklch(0.645 0.246 16.439);
+	--fcaf-data-model: oklch(0.75 0.11 262);
+	--fcaf-message-structure: oklch(0.77 0.1 200);
+	--fcaf-interaction: oklch(0.78 0.12 45);
+	--fcaf-security-mechanisms: oklch(0.74 0.12 330);
+	--fcaf-shared: oklch(0.75 0.1 155);
+	--fcaf-use-cases: oklch(0.8 0.12 85);
 	--sidebar: oklch(0.208 0.042 265.755);
 	--sidebar-foreground: oklch(0.984 0.003 247.858);
 	--sidebar-primary: oklch(0.488 0.243 264.376);
@@ -110,6 +122,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	--color-chart-3: var(--chart-3);
 	--color-chart-4: var(--chart-4);
 	--color-chart-5: var(--chart-5);
+	--color-fcaf-data-model: var(--fcaf-data-model);
+	--color-fcaf-message-structure: var(--fcaf-message-structure);
+	--color-fcaf-interaction: var(--fcaf-interaction);
+	--color-fcaf-security-mechanisms: var(--fcaf-security-mechanisms);
+	--color-fcaf-shared: var(--fcaf-shared);
+	--color-fcaf-use-cases: var(--fcaf-use-cases);
 	--color-sidebar: var(--sidebar);
 	--color-sidebar-foreground: var(--sidebar-foreground);
 	--color-sidebar-primary: var(--sidebar-primary);


### PR DESCRIPTION
## What

Group FCAF assessment checks by their canonical area (Data model, Message structure, Interaction, Security mechanisms, Shared, Use cases) instead of the previous flat/per-test listing, in both the web report sheet and the generated PDF.

## Web sheet

- Group checks by area with a color-coded vertical rail, collapsible subsections, and per-group pass-rate bars.
- Pinned header: status filters, search, expand/collapse all, and a clickable color legend that scrolls to each area.
- New `--fcaf-*` color tokens (light + dark) in `layout.css`.

## PDF

- Group tests by area → subsection, with a "Test groups" summary page (colour key + per-area pass counts) after the executive summary.
- One test per page; removed the mono-font title box.
- Footer shows the subsection + a thin color bar + `Test N of M · Page N`.
- Visual evidence rendered in a 2-column grid with numbered `Evidence N` captions and full filenames listed contextually.
- Runner name/type/serial resolved from the pipeline and shown on the cover.
- Marketing back cover with contact details; footer suppressed on the back cover.

## Validation

- `go test ./pkg/fcaf/...`, `go vet`, `gofmt`.
- `bun run check` (0 errors), `bun run test:unit` (FCAF categories), `bun run build`.
