### PR TITLE
feat(pipeline): add running-run progress bar with ETA

### DIFF
--- a/pkg/internal/apis/handlers/pipeline_progress.go
+++ b/pkg/internal/apis/handlers/pipeline_progress.go
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/forkbombeu/credimi/pkg/utils"
+	workflowengine "github.com/forkbombeu/credimi/pkg/workflowengine"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+)
+
+// progressHistoryLimit caps how many completed runs are inspected per estimate.
+const progressHistoryLimit = 25
+
+// progressMaxSamples caps how many durations feed the estimate.
+const progressMaxSamples = 10
+
+// PipelineProgress describes the estimated advancement of a running pipeline
+// execution, derived from the durations of previous completed runs of the same
+// pipeline (runner-matched when possible).
+type PipelineProgress struct {
+	// ExpectedDurationSeconds is the estimated total duration of the run.
+	ExpectedDurationSeconds float64 `json:"expected_duration_seconds"`
+	// ElapsedSeconds is the time since the workflow started.
+	ElapsedSeconds float64 `json:"elapsed_seconds"`
+	// Percent is the estimated completion percentage, capped at 100.
+	Percent float64 `json:"percent"`
+	// EtaSeconds is the estimated remaining time.
+	EtaSeconds float64 `json:"eta_seconds"`
+	// SampleSize is the number of previous runs backing the estimate.
+	SampleSize int `json:"sample_size"`
+}
+
+// computePipelineProgress estimates the progress of a running pipeline
+// execution from the durations of previous completed runs of the same
+// pipeline, preferring runs executed by the same runners.
+func computePipelineProgress(
+	ctx context.Context,
+	b *pipelineExecutionSummaryBuilder,
+	pipelineIdentifier string,
+	runnerIDs []string,
+	startTime string,
+) *PipelineProgress {
+	if b == nil || b.client == nil {
+		return nil
+	}
+	normalized := workflowengine.NormalizePipelineIdentifier(pipelineIdentifier)
+	if normalized == "" {
+		return nil
+	}
+
+	start, err := utils.ParseTimeString(startTime)
+	if err != nil {
+		return nil
+	}
+	elapsed := time.Since(start)
+	if elapsed < 0 {
+		return nil
+	}
+
+	expected, samples := expectedPipelineDuration(
+		ctx,
+		b.client,
+		b.namespace,
+		normalized,
+		runnerIDs,
+	)
+	if expected <= 0 {
+		return nil
+	}
+
+	percent := elapsed.Seconds() / expected * 100
+	if percent > 100 {
+		percent = 100
+	}
+	eta := expected - elapsed.Seconds()
+	if eta < 0 {
+		eta = 0
+	}
+	return &PipelineProgress{
+		ExpectedDurationSeconds: expected,
+		ElapsedSeconds:          elapsed.Seconds(),
+		Percent:                 percent,
+		EtaSeconds:              eta,
+		SampleSize:              samples,
+	}
+}
+
+// expectedPipelineDuration returns the median duration of recent completed
+// runs of the given pipeline. Runs are filtered by runner identifiers when the
+// current run declares them and matching history exists.
+func expectedPipelineDuration(
+	ctx context.Context,
+	temporalClient client.Client,
+	namespace string,
+	pipelineIdentifier string,
+	runnerIDs []string,
+) (float64, int) {
+	query := buildPipelineWorkflowsQuery(
+		[]enums.WorkflowExecutionStatus{enums.WORKFLOW_EXECUTION_STATUS_COMPLETED},
+		pipelineIdentifier,
+	)
+
+	resp, err := temporalClient.ListWorkflow(
+		ctx,
+		&workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: namespace,
+			Query:     query,
+			PageSize:  progressHistoryLimit,
+		},
+	)
+	if err != nil {
+		return 0, 0
+	}
+
+	durations := make([]float64, 0, progressMaxSamples)
+
+	for _, execInfo := range resp.GetExecutions() {
+		if execInfo == nil || execInfo.GetStartTime() == nil {
+			continue
+		}
+		if len(runnerIDs) > 0 {
+			attrs, err := decodeWorkflowSearchAttributes(execInfo.GetSearchAttributes())
+			if err != nil || attrs == nil {
+				continue
+			}
+			if historyRunners := runnerIDsFromSearchAttributes(&attrs); len(historyRunners) > 0 &&
+				!runnerSetsIntersect(runnerIDs, historyRunners) {
+				continue
+			}
+		}
+
+		closeTime := execInfo.GetCloseTime()
+		if closeTime == nil {
+			continue
+		}
+		start := execInfo.GetStartTime()
+		if execInfo.GetExecutionTime() != nil {
+			start = execInfo.GetExecutionTime()
+		}
+		duration := closeTime.AsTime().Sub(start.AsTime())
+		if duration <= 0 {
+			continue
+		}
+		durations = append(durations, duration.Seconds())
+		if len(durations) >= progressMaxSamples {
+			break
+		}
+	}
+	if len(durations) == 0 {
+		return 0, 0
+	}
+
+	sort.Float64s(durations)
+	median := durations[len(durations)/2]
+	if len(durations)%2 == 0 {
+		median = (durations[len(durations)/2-1] + median) / 2
+	}
+	return median, len(durations)
+}
+
+// runnerIDsFromSearchAttributes extracts the RunnerIdentifiers keyword list
+// from decoded Temporal search attributes.
+func runnerIDsFromSearchAttributes(
+	attributes *DecodedWorkflowSearchAttributes,
+) []string {
+	if attributes == nil {
+		return nil
+	}
+	value, ok := (*attributes)[workflowengine.RunnerIdentifiersSearchAttribute]
+	if !ok {
+		return nil
+	}
+	switch typed := value.(type) {
+	case []string:
+		return typed
+	case []any:
+		ids := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if s, ok := item.(string); ok && s != "" {
+				ids = append(ids, s)
+			}
+		}
+		return ids
+	}
+	return nil
+}
+
+func runnerSetsIntersect(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, id := range a {
+		set[strings.TrimSpace(id)] = struct{}{}
+	}
+	for _, id := range b {
+		if _, ok := set[strings.TrimSpace(id)]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/internal/apis/handlers/pipeline_progress_test.go
+++ b/pkg/internal/apis/handlers/pipeline_progress_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/forkbombeu/credimi/pkg/internal/temporalcrypto"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	workflow "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	temporalmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestRunnerSetsIntersect(t *testing.T) {
+	require.True(t, runnerSetsIntersect([]string{"a", "b"}, []string{"b"}))
+	require.True(t, runnerSetsIntersect([]string{" a "}, []string{"a"}))
+	require.False(t, runnerSetsIntersect([]string{"a"}, []string{"b"}))
+	require.False(t, runnerSetsIntersect(nil, []string{"b"}))
+}
+
+func TestRunnerIDsFromSearchAttributes(t *testing.T) {
+	require.Nil(t, runnerIDsFromSearchAttributes(nil))
+
+	stringList := DecodedWorkflowSearchAttributes{
+		"RunnerIdentifiers": []string{"runner-1", "runner-2"},
+	}
+	require.Equal(
+		t,
+		[]string{"runner-1", "runner-2"},
+		runnerIDsFromSearchAttributes(&stringList),
+	)
+
+	anyList := DecodedWorkflowSearchAttributes{
+		"RunnerIdentifiers": []any{"runner-1", "", 42},
+	}
+	require.Equal(t, []string{"runner-1"}, runnerIDsFromSearchAttributes(&anyList))
+
+	missing := DecodedWorkflowSearchAttributes{"Other": "x"}
+	require.Nil(t, runnerIDsFromSearchAttributes(&missing))
+}
+
+func progressHistoryClient(
+	t *testing.T,
+	executions []*workflow.WorkflowExecutionInfo,
+) *temporalmocks.Client {
+	t.Helper()
+	mockClient := &temporalmocks.Client{}
+	mockClient.
+		On("ListWorkflow", mock.Anything, mock.Anything).
+		Return(&workflowservice.ListWorkflowExecutionsResponse{Executions: executions}, nil)
+	return mockClient
+}
+
+func TestExpectedPipelineDurationMedian(t *testing.T) {
+	now := time.Now()
+	executions := make([]*workflow.WorkflowExecutionInfo, 0, 3)
+	for _, seconds := range []float64{60, 120, 300} {
+		executions = append(executions, &workflow.WorkflowExecutionInfo{
+			StartTime:     timestamppb.New(now.Add(-2 * time.Hour)),
+			ExecutionTime: timestamppb.New(now.Add(-2 * time.Hour)),
+			CloseTime: timestamppb.New(
+				now.Add(-2*time.Hour + time.Duration(seconds)*time.Second),
+			),
+			Status: 1,
+		})
+	}
+
+	duration, samples := expectedPipelineDuration(
+		context.Background(),
+		progressHistoryClient(t, executions),
+		"ns",
+		"tenant/pipeline",
+		nil,
+	)
+	require.Equal(t, 3, samples)
+	require.InDelta(t, 120.0, duration, 0.001)
+}
+
+func TestExpectedPipelineDurationFiltersByRunner(t *testing.T) {
+	converter := temporalcrypto.DataConverter()
+	runnerPayloads := map[string]*commonpb.Payload{}
+	for _, runner := range []string{"runner-1", "runner-2"} {
+		payload, err := converter.ToPayloads([]string{runner})
+		require.NoError(t, err)
+		runnerPayloads[runner] = payload.GetPayloads()[0]
+	}
+
+	now := time.Now()
+	newExecution := func(runners string, durationSeconds float64) *workflow.WorkflowExecutionInfo {
+		info := &workflow.WorkflowExecutionInfo{
+			StartTime:     timestamppb.New(now.Add(-2 * time.Hour)),
+			ExecutionTime: timestamppb.New(now.Add(-2 * time.Hour)),
+			CloseTime: timestamppb.New(
+				now.Add(-2*time.Hour + time.Duration(durationSeconds)*time.Second),
+			),
+			Status: 1,
+		}
+		if runners != "" {
+			info.SearchAttributes = &commonpb.SearchAttributes{
+				IndexedFields: map[string]*commonpb.Payload{
+					"RunnerIdentifiers": runnerPayloads[runners],
+				},
+			}
+		}
+		return info
+	}
+
+	// runner-2 runs take 120s; the runner-1 run takes 600s and must be excluded.
+	executions := []*workflow.WorkflowExecutionInfo{
+		newExecution("runner-2", 120),
+		newExecution("runner-2", 120),
+		newExecution("runner-1", 600),
+	}
+
+	duration, samples := expectedPipelineDuration(
+		context.Background(),
+		progressHistoryClient(t, executions),
+		"ns",
+		"tenant/pipeline",
+		[]string{"runner-2"},
+	)
+	require.Equal(t, 2, samples)
+	require.InDelta(t, 120.0, duration, 0.001)
+}
+
+func TestComputePipelineProgressGuards(t *testing.T) {
+	require.Nil(t, computePipelineProgress(
+		context.Background(), nil, "tenant/pipeline", nil, "",
+	))
+
+	builder := newPipelineExecutionSummaryBuilder(nil, progressHistoryClient(t, nil), "ns", "UTC")
+	require.Nil(t, computePipelineProgress(
+		context.Background(), builder, "", nil, "",
+	))
+	require.Nil(t, computePipelineProgress(
+		context.Background(), builder, "tenant/pipeline", nil, "not-a-time",
+	))
+
+	// No history: no estimate.
+	require.Nil(t, computePipelineProgress(
+		context.Background(),
+		builder,
+		"tenant/pipeline",
+		nil,
+		time.Now().Add(-time.Minute).Format(time.RFC3339Nano),
+	))
+}
+
+func TestComputePipelineProgressEstimates(t *testing.T) {
+	now := time.Now()
+	executions := []*workflow.WorkflowExecutionInfo{
+		{
+			StartTime:     timestamppb.New(now.Add(-3 * time.Hour)),
+			ExecutionTime: timestamppb.New(now.Add(-3 * time.Hour)),
+			CloseTime:     timestamppb.New(now.Add(-3*time.Hour + 120*time.Second)),
+			Status:        1,
+		},
+	}
+
+	progress := computePipelineProgress(
+		context.Background(),
+		newPipelineExecutionSummaryBuilder(nil, progressHistoryClient(t, executions), "ns", "UTC"),
+		"tenant/pipeline",
+		nil,
+		now.Add(-30*time.Second).Format(time.RFC3339Nano),
+	)
+	require.NotNil(t, progress)
+	require.Equal(t, 1, progress.SampleSize)
+	require.InDelta(t, 120.0, progress.ExpectedDurationSeconds, 0.001)
+	require.InDelta(t, 30.0, progress.ElapsedSeconds, 2.0)
+	require.InDelta(t, 25.0, progress.Percent, 3.0)
+	require.InDelta(t, 90.0, progress.EtaSeconds, 3.0)
+}
+
+func TestExpectedPipelineDurationListError(t *testing.T) {
+	mockClient := &temporalmocks.Client{}
+	mockClient.
+		On("ListWorkflow", mock.Anything, mock.Anything).
+		Return(nil, &serviceerror.NotFound{Message: "none"})
+
+	duration, samples := expectedPipelineDuration(
+		context.Background(),
+		mockClient,
+		"ns",
+		"tenant/pipeline",
+		nil,
+	)
+	require.Zero(t, duration)
+	require.Zero(t, samples)
+}

--- a/pkg/internal/apis/handlers/pipeline_results_handler.go
+++ b/pkg/internal/apis/handlers/pipeline_results_handler.go
@@ -677,6 +677,15 @@ func (b *pipelineExecutionSummaryBuilder) Build(
 			b.runnerCache,
 		),
 	}
+	if rootSummary.Status == string(WorkflowStatusRunning) {
+		summary.Progress = computePipelineProgress(
+			ctx,
+			b,
+			pipelineIdentifier,
+			runnerIDs,
+			rootSummary.StartTime,
+		)
+	}
 	summary.PipelineIdentifier = pipelineIdentifier
 	summary.PipelineName = resolvePipelineNameFromRecord(pipelineRecord, pipelineIdentifier)
 	localizePipelineWorkflowSummaries([]*pipelineWorkflowSummary{summary}, b.location)
@@ -995,11 +1004,12 @@ func describeWorkflowExecution(
 
 type pipelineWorkflowSummary struct {
 	WorkflowExecutionSummary
-	PipelineIdentifier string           `json:"pipeline_identifier,omitempty"`
-	PipelineName       string           `json:"pipeline_name,omitempty"`
-	GlobalRunnerID     string           `json:"global_runner_id,omitempty"`
-	RunnerIDs          []string         `json:"runner_ids,omitempty"`
-	RunnerRecords      []map[string]any `json:"runner_records,omitempty"`
+	Progress           *PipelineProgress `json:"progress,omitempty"`
+	PipelineIdentifier string            `json:"pipeline_identifier,omitempty"`
+	PipelineName       string            `json:"pipeline_name,omitempty"`
+	GlobalRunnerID     string            `json:"global_runner_id,omitempty"`
+	RunnerIDs          []string          `json:"runner_ids,omitempty"`
+	RunnerRecords      []map[string]any  `json:"runner_records,omitempty"`
 }
 
 func appendQueuedPipelineSummaries(

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -970,6 +970,7 @@
 	"Failed_to_cancel_pipeline": "Failed to cancel pipeline",
 	"Pipeline_execution_canceled": "Pipeline execution canceled",
 	"Queued": "Queued",
+	"eta_remaining": "~{time} left",
 	"Configure_integration": "Configure integration",
 	"Configure_integration_description": "Set the parameters for this integration before running.",
 	"Custom_integration_started_successfully": "Custom integration started successfully",

--- a/webapp/src/lib/pipeline/execution-progress.svelte
+++ b/webapp/src/lib/pipeline/execution-progress.svelte
@@ -1,0 +1,92 @@
+<!--
+SPDX-FileCopyrightText: 2026 Forkbomb BV
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+	import { m } from '@/i18n';
+
+	import { formatDurationParts, type PipelineProgress } from './progress';
+
+	//
+
+	type Props = {
+		progress?: PipelineProgress | null;
+	};
+
+	let { progress }: Props = $props();
+
+	//
+
+	let now = $state(Date.now());
+	let snapshot = $state({ elapsed: 0, at: Date.now() });
+
+	$effect(() => {
+		if (progress) {
+			snapshot = { elapsed: progress.elapsed_seconds, at: Date.now() };
+		}
+	});
+
+	$effect(() => {
+		const interval = setInterval(() => (now = Date.now()), 1000);
+		return () => clearInterval(interval);
+	});
+
+	const elapsed = $derived(
+		progress ? snapshot.elapsed + Math.max(0, (now - snapshot.at) / 1000) : 0
+	);
+	const percent = $derived(
+		progress ? Math.min((elapsed / progress.expected_duration_seconds) * 100, 99) : null
+	);
+	const eta = $derived(
+		progress ? Math.max(progress.expected_duration_seconds - elapsed, 0) : null
+	);
+</script>
+
+<div class="mt-1 w-32 min-w-24">
+	{#if progress && percent !== null && eta !== null}
+		<div
+			class="h-1.5 w-full overflow-hidden rounded-full bg-slate-200"
+			role="progressbar"
+			aria-valuenow={Math.round(percent)}
+			aria-valuemin={0}
+			aria-valuemax={100}
+		>
+			<div
+				class="h-full rounded-full bg-primary transition-[width] duration-1000 ease-linear"
+				style="width: {percent}%"
+			></div>
+		</div>
+		<p class="mt-0.5 text-[10px] whitespace-nowrap text-muted-foreground">
+			<span class="font-mono">{Math.round(percent)}%</span>
+			·
+			{m.eta_remaining({ time: formatDurationParts(eta) })}
+		</p>
+	{:else}
+		<div
+			class="h-1.5 w-full overflow-hidden rounded-full bg-slate-200"
+			role="progressbar"
+			aria-label={m.Running()}
+		>
+			<div class="indeterminate h-full w-1/3 rounded-full bg-primary"></div>
+		</div>
+	{/if}
+</div>
+
+<style lang="postcss">
+	@reference "tailwindcss";
+
+	.indeterminate {
+		animation: progress-slide 1.5s ease-in-out infinite;
+	}
+
+	@keyframes progress-slide {
+		0% {
+			transform: translateX(-100%);
+		}
+		100% {
+			transform: translateX(300%);
+		}
+	}
+</style>

--- a/webapp/src/lib/pipeline/progress.spec.ts
+++ b/webapp/src/lib/pipeline/progress.spec.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import { formatDurationParts } from './progress';
+
+describe('formatDurationParts', () => {
+	it('formats seconds only', () => {
+		expect(formatDurationParts(45)).toBe('45s');
+	});
+
+	it('formats minutes and seconds', () => {
+		expect(formatDurationParts(133)).toBe('2m 13s');
+	});
+
+	it('formats hours and minutes', () => {
+		expect(formatDurationParts(3725)).toBe('1h 2m');
+	});
+
+	it('clamps negative values to zero', () => {
+		expect(formatDurationParts(-10)).toBe('0s');
+	});
+});

--- a/webapp/src/lib/pipeline/progress.ts
+++ b/webapp/src/lib/pipeline/progress.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//
+
+export interface PipelineProgress {
+	expected_duration_seconds: number;
+	elapsed_seconds: number;
+	percent: number;
+	eta_seconds: number;
+	sample_size: number;
+}
+
+/** Formats seconds as a compact human duration, e.g. "2m 13s". */
+export function formatDurationParts(totalSeconds: number): string {
+	const seconds = Math.max(0, Math.round(totalSeconds));
+	const h = Math.floor(seconds / 3600);
+	const min = Math.floor((seconds % 3600) / 60);
+	const s = seconds % 60;
+	if (h > 0) return `${h}h ${min}m`;
+	if (min > 0) return `${min}m ${s}s`;
+	return `${s}s`;
+}

--- a/webapp/src/lib/pipeline/workflows-table-small.svelte
+++ b/webapp/src/lib/pipeline/workflows-table-small.svelte
@@ -16,6 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 	import { makeDropdownActions } from './actions';
 	import { fromApiSummary } from './execution-artifacts';
+	import ExecutionProgress from './execution-progress.svelte';
 	import ExecutionArtifactsPreview from './results/execution-artifacts-preview.svelte';
 	import WorkflowStatusTag from './workflow-status-tag.svelte';
 	import * as PipelineWorkflows from './workflows';
@@ -57,6 +58,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 									failureReason={workflow.failure_reason}
 									size="sm"
 								/>
+								{#if workflow.status === 'Running'}
+									<ExecutionProgress progress={workflow.progress} />
+								{/if}
 							</td>
 							<td>
 								{#if runnerNames.length > 0}

--- a/webapp/src/lib/pipeline/workflows.ts
+++ b/webapp/src/lib/pipeline/workflows.ts
@@ -8,6 +8,8 @@ import type { MobileRunnersResponse } from '@/pocketbase/types';
 
 import { pb } from '@/pocketbase';
 
+import type { PipelineProgress } from './progress';
+
 import StatusTag from './workflow-status-tag.svelte';
 import SmallTable from './workflows-table-small.svelte';
 import Table from './workflows-table.svelte';
@@ -25,6 +27,7 @@ export interface ExecutionSummary extends Workflow.WorkflowExecutionSummary {
 	runner_ids?: string[];
 	enqueuedAt?: string;
 	runner_records?: Array<MobileRunnersResponse>;
+	progress?: PipelineProgress;
 	queue?: {
 		ticket_id: string;
 		position: number;


### PR DESCRIPTION
## What

Running pipeline executions on `/my/pipelines` now render a live progress bar with an ETA next to the status tag.

## How

- Backend (`pkg/internal/apis/handlers/pipeline_progress.go`): for running pipeline workflows, the execution summary gains a `progress` object (`expected_duration_seconds`, `elapsed_seconds`, `percent`, `eta_seconds`, `sample_size`).
- The estimate is the median duration of the last 10 completed runs of the same pipeline, fetched from Temporal visibility (`PipelineIdentifier` + `ExecutionStatus = Completed`).
- Runs are runner-matched via the `RunnerIdentifiers` search attribute when the current run declares runners; no silent fallback to other runners' durations.
- Canceled, terminated, timed-out, and failed runs never enter the estimate.
- Frontend: `execution-progress.svelte` renders in the status cell of the small workflows table. Ticks every second client-side between the 10s polls by advancing the server-reported elapsed time; display clamps at 99% until the run finishes. No estimate available → indeterminate bar.

## Validation

- Go: `gofmt`, `go vet`, `golangci-lint` (0 issues), `go mod tidy -diff` clean; full `go test -tags=unit ./pkg/internal/apis/handlers/` passes, including new estimate tests (median, runner filtering, guards, progress math).
- Webapp: `bun run check` 0 errors; eslint/prettier clean on touched files; unit tests pass (165 + 4 new formatter tests).
- Note: `bun run lint` fails repo-wide on pre-existing unformatted `webapp/project.inlang/.meta.json` and `README.md` (untouched by this PR).