### PR TITLE
fix(tools): repair stepci runner docker symlink

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -10,5 +10,5 @@ bun = "1.3.12"
 node = "24.13.0"
 "aqua:dyne/slangroom-exec" = "latest"
 pre-commit = "latest"
-"github:forkbombeu/stepci-captured-runner" = "latest"
+"github:forkbombeu/stepci-captured-runner" = { version = "latest", bin = "stepci-captured-runner" }
 "github:forkbombeu/et-tu-cesr" = "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,9 @@ COPY .mise.toml ./
 RUN mise trust
 RUN --mount=type=cache,target=/mise/cache mise i
 RUN mkdir -p .bin && \
-    ln -sf "$$(mise which et-tu-cesr)" .bin/et-tu-cesr && \
-    ln -sf "$$(mise which stepci-captured-runner-Linux)" .bin/stepci-captured-runner
+    ln -sf "$(mise which et-tu-cesr)" .bin/et-tu-cesr && \
+    ln -sf "$(mise which stepci-captured-runner)" .bin/stepci-captured-runner && \
+    test -x .bin/et-tu-cesr && test -x .bin/stepci-captured-runner
 
 # install bun deps and cache
 COPY ./webapp/package.json webapp/

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,8 @@ devtools: generate
 tools: generate $(BIN)
 	mise install
 	ln -sf "$$(mise which et-tu-cesr)" "$(BIN)/et-tu-cesr"
-	ln -sf "$$(mise which stepci-captured-runner-Linux)" "$(BIN)/stepci-captured-runner"
+	ln -sf "$$(mise which stepci-captured-runner)" "$(BIN)/stepci-captured-runner"
+	test -x "$(BIN)/et-tu-cesr" && test -x "$(BIN)/stepci-captured-runner"
 
 ## Help:
 help: ## Show this help.


### PR DESCRIPTION
## Problem

After ad37fff6 (mise-based tool install), production pipelines fail with:

```
CRE301 StepCI command failed: stepci-captured-runner exited with error:
fork/exec .bin/stepci-captured-runner: no such file or directory
```

## Root causes

1. **Dockerfile `$$` escaping.** The Dockerfile parser does not treat `$$` as `$` (that is a Compose/Make convention). The build shell received `$$`, expanded it to the PID (`1` in the container), and created the symlink `1(mise which stepci-captured-runner-Linux)`. Since `ln -sf` never validates its target, the image built fine and the broken link only surfaced at runtime as `fork/exec ... no such file or directory`.
2. **Hardcoded `-Linux` suffix.** mise's github backend strips lowercase OS/arch tokens from single-binary asset names; the uppercase `Linux` in the `stepci-captured-runner-Linux-x86_64` asset is not recognized, so only `-x86_64` is stripped. This is Linux-only and unpinned; on macOS the binary is `...-Darwin`.

## Fix

- `.mise.toml`: pin the executable with `bin = "stepci-captured-runner"` (the mise-documented option for single-binary downloads), so `mise which stepci-captured-runner` is platform-independent.
- `Dockerfile`: single `$` command substitution, plain `mise which stepci-captured-runner`, plus `test -x` checks so a broken symlink now fails the build instead of shipping.
- `Makefile`: same plain name and `test -x` guards.

## Validation

- `make tools` passes locally; `.bin/stepci-captured-runner --version` → `1.4.0`, `et-tu-cesr` → `1.2.3`.
- Docker probe replicating the exact mise install + symlink steps from the Dockerfile (debian:12-slim, same `MISE_*` env): both symlinks resolve in-container and both binaries execute.
- Repro test of the bug confirmed Docker builds previously produced `link -> 1(mise which stepci-captured-runner-Linux)`.

## Notes

- Fixes #1335 regression (the mise migration itself).