### PR TITLE
fix(scoreboard): hide unpublished pipelines from public cards

### DIFF
--- a/webapp/src/lib/scoreboard/records/index.test.ts
+++ b/webapp/src/lib/scoreboard/records/index.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import type { ScoreboardRow } from '../types';
+
+import { hasVisiblePipeline, PUBLISHED_PIPELINE_FILTER } from './index';
+
+describe('scoreboard records visibility', () => {
+	it('exposes a published-pipeline filter for public listings', () => {
+		expect(PUBLISHED_PIPELINE_FILTER).toBe('pipeline.published = true');
+	});
+
+	it('treats rows with an expanded pipeline as visible', () => {
+		const row = {
+			expand: {
+				pipeline: {
+					id: 'pipe1',
+					name: 'Capture Wallet Metadata Issue and Verification of credential',
+					published: true
+				}
+			}
+		} as ScoreboardRow;
+
+		expect(hasVisiblePipeline(row)).toBe(true);
+	});
+
+	it('hides rows whose pipeline expand is missing (unpublished / private)', () => {
+		const row = {
+			id: 'cache1',
+			pipeline: 'hidden-pipeline-id',
+			expand: {}
+		} as ScoreboardRow;
+
+		expect(hasVisiblePipeline(row)).toBe(false);
+	});
+});

--- a/webapp/src/lib/scoreboard/records/index.ts
+++ b/webapp/src/lib/scoreboard/records/index.ts
@@ -15,6 +15,15 @@ import type { ScoreboardRow } from '../types';
 
 //
 
+/** Public scoreboard listings must only include published pipelines.
+ * Unpublished pipelines still exist in the cache, but their `pipeline`
+ * expand is omitted for anonymous viewers, which left cards with no title. */
+export const PUBLISHED_PIPELINE_FILTER = 'pipeline.published = true';
+
+export function hasVisiblePipeline(row: ScoreboardRow): boolean {
+	return Boolean(row.expand?.pipeline);
+}
+
 const agent = new PocketbaseQueryAgent({
 	collection: 'pipeline_scoreboard_cache',
 	expand: [
@@ -53,6 +62,7 @@ export async function loadPage(options: LoadPageOptions = {}): Promise<ListResul
 	const res = await agent.getList(options.page ?? 1, options.perPage, {
 		fetch: options.fetch,
 		requestKey: null,
+		filter: PUBLISHED_PIPELINE_FILTER,
 		...(options.sort ? { sort: options.sort } : {})
 	});
 	return res as ListResult<ScoreboardRow>;

--- a/webapp/src/routes/(public)/_partials/scoreboard-section.svelte
+++ b/webapp/src/routes/(public)/_partials/scoreboard-section.svelte
@@ -9,8 +9,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 	import { entities, EntityTag } from '$lib/global';
 	import CardLink from '$lib/layout/card-link.svelte';
-	import * as EntityDisplay from '$lib/scoreboard/entity-display';
 	import PipelineContentSummary from '$lib/scoreboard/extras/pipeline-content-summary.svelte';
+	import { hasVisiblePipeline } from '$lib/scoreboard/records';
 	import { getPath } from '$lib/utils';
 
 	type Props = {
@@ -20,6 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	let { records }: Props = $props();
 
 	const cardClass = 'flex flex-col flex-wrap justify-between gap-4 p-3! md:flex-row';
+	const visibleRecords = $derived(records.filter(hasVisiblePipeline));
 </script>
 
 {#snippet scoreboardContent(record: ScoreboardRow)}
@@ -27,13 +28,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	<div class="flex flex-col items-start gap-2 md:flex-row md:items-center">
 		<EntityTag data={entities.pipelines} />
 		<div class="text-sm">
-			<p>
-				{#if pipeline}
-					{pipeline.name}
-				{:else}
-					<EntityDisplay.Na />
-				{/if}
-			</p>
+			<p>{pipeline?.name}</p>
 			<p class="font-bold">
 				• {record.total_successes} / {record.total_runs} ({record.success_rate}%)
 			</p>
@@ -44,21 +39,23 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 {/snippet}
 
 <div class="space-y-2">
-	{#each records as record (record.id)}
+	{#each visibleRecords as record (record.id)}
 		{@const pipeline = record.expand?.pipeline}
-		{#if pipeline?.published}
-			<CardLink href={`/hub/pipelines/${getPath(pipeline)}`} class={cardClass}>
-				{@render scoreboardContent(record)}
-			</CardLink>
-		{:else}
-			<div
-				class={[
-					'block rounded-lg border border-primary bg-card text-card-foreground shadow-sm',
-					cardClass
-				]}
-			>
-				{@render scoreboardContent(record)}
-			</div>
+		{#if pipeline}
+			{#if pipeline.published}
+				<CardLink href={`/hub/pipelines/${getPath(pipeline)}`} class={cardClass}>
+					{@render scoreboardContent(record)}
+				</CardLink>
+			{:else}
+				<div
+					class={[
+						'block rounded-lg border border-primary bg-card text-card-foreground shadow-sm',
+						cardClass
+					]}
+				>
+					{@render scoreboardContent(record)}
+				</div>
+			{/if}
 		{/if}
 	{/each}
 </div>


### PR DESCRIPTION
## Summary
- Public home/scoreboard listings queried unpublished `pipeline_scoreboard_cache` rows whose `pipeline` expand is omitted for anonymous viewers, so cards rendered with a blank title (`—`).
- Filter `loadPage` with `pipeline.published = true`, and skip rows without a visible pipeline expand in the home scoreboard section.
- Add regression coverage for the visibility helper and published filter constant.

## Test plan
- [ ] Open `https://credimi.io/` (or local home) and confirm every “Compare by test results” card has a pipeline name (no `—` titles).
- [ ] Confirm published pipelines still appear with correct titles and hub links.
- [ ] Open `/scoreboard` and confirm pagination/listing no longer includes untitled private pipelines.
- [ ] `cd webapp && bun run test:unit -- --run src/lib/scoreboard/records/index.test.ts`


Made with [Cursor](https://cursor.com)