### PR TITLE
fix(scoreboard): follow current pipeline published state

### DIFF
--- a/pkg/internal/apis/handlers/pipeline_queue_handler.go
+++ b/pkg/internal/apis/handlers/pipeline_queue_handler.go
@@ -195,7 +195,6 @@ func enqueuePipelineRun(
 	if runContext.metadata != nil {
 		memo["metadata"] = runContext.metadata
 	}
-	memo[pipelineinternal.PublishedMemoKey] = runContext.pipelineRecord.GetBool("published")
 	config := buildPipelineQueueConfig(e, namespace, runContext.userName, runContext.userEmail)
 	applyPipelineQueueCleanupConfig(config, runContext.cleanup)
 

--- a/pkg/internal/apis/handlers/pipeline_queue_handler_test.go
+++ b/pkg/internal/apis/handlers/pipeline_queue_handler_test.go
@@ -376,14 +376,12 @@ func TestPipelineQueueEnqueue_StartsNonRunnerPipeline(t *testing.T) {
 	t.Cleanup(func() {
 		startPipelineWorkflow = origStart
 	})
-	var capturedMemo map[string]any
 	startPipelineWorkflow = func(
 		yaml string,
 		config map[string]any,
 		memo map[string]any,
 		pipelineIdentifier string,
 	) (workflowengine.WorkflowResult, error) {
-		capturedMemo = memo
 		return workflowengine.WorkflowResult{
 			WorkflowID:    "wf-123",
 			WorkflowRunID: "run-456",
@@ -454,7 +452,6 @@ func TestPipelineQueueEnqueue_StartsNonRunnerPipeline(t *testing.T) {
 	require.Equal(t, "wf-123", results[0].GetString("workflow_id"))
 	require.Equal(t, "run-456", results[0].GetString("run_id"))
 	require.Equal(t, pipelineinternal.RunTypeManual, results[0].GetString("type"))
-	require.Equal(t, false, capturedMemo[pipelineinternal.PublishedMemoKey])
 }
 
 func TestPipelineQueueStatusReturnsRunURL(t *testing.T) {

--- a/pkg/internal/apis/handlers/scoreboard.go
+++ b/pkg/internal/apis/handlers/scoreboard.go
@@ -447,7 +447,7 @@ func HandleGetPipelineScoreboard() func(*core.RequestEvent) error {
 			if pipelineRecord == nil {
 				continue
 			}
-			if !workflowExecutionVisibleOnScoreboard(exec, pipelineRecord) {
+			if !pipelineRecord.GetBool("published") {
 				continue
 			}
 			executionsByPipelineID[pipelineRecord.Id] = append(
@@ -497,32 +497,6 @@ func HandleGetPipelineScoreboard() func(*core.RequestEvent) error {
 		}
 		return e.JSON(http.StatusOK, response)
 	}
-}
-
-func workflowExecutionVisibleOnScoreboard(
-	exec *WorkflowExecution,
-	pipelineRecord *core.Record,
-) bool {
-	published, ok := workflowExecutionPublishedMemo(exec)
-	if ok {
-		return published
-	}
-	return pipelineRecord != nil && pipelineRecord.GetBool(pipelineinternal.PublishedMemoKey)
-}
-
-func workflowExecutionPublishedMemo(exec *WorkflowExecution) (bool, bool) {
-	if exec == nil || exec.Memo == nil {
-		return false, false
-	}
-	field, ok := exec.Memo.Fields[pipelineinternal.PublishedMemoKey]
-	if !ok || field == nil || field.Data == nil {
-		return false, false
-	}
-	published, err := strconv.ParseBool(DecodeFromTemporalPayload(*field.Data))
-	if err != nil {
-		return false, false
-	}
-	return published, true
 }
 
 func HandleGetExecutionDetails() func(*core.RequestEvent) error {

--- a/pkg/internal/apis/handlers/scoreboard_test.go
+++ b/pkg/internal/apis/handlers/scoreboard_test.go
@@ -286,7 +286,6 @@ func TestHandleGetPipelineScoreboard(t *testing.T) {
 		now.Add(-10*time.Minute).Add(-5*time.Second),
 		now.Add(-10*time.Minute),
 	)
-	setWorkflowExecutionPublished(t, exec6.Info, false)
 	exec7 := buildPipelineExecutionInfoWithRunner(
 		t,
 		"wf-7",
@@ -404,7 +403,7 @@ func TestHandleGetPipelineScoreboard(t *testing.T) {
 	var response []PipelineStatsResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
 
-	require.Len(t, response, 3)
+	require.Len(t, response, 2)
 
 	var stats1, stats2, stats3 *PipelineStatsResponse
 	for i := range response {
@@ -420,31 +419,34 @@ func TestHandleGetPipelineScoreboard(t *testing.T) {
 	}
 
 	require.NotNil(t, stats1)
-	require.Equal(t, 3, stats1.TotalRuns)
-	require.Equal(t, 2, stats1.TotalSuccesses)
+	require.Equal(t, 4, stats1.TotalRuns)
+	require.Equal(t, 3, stats1.TotalSuccesses)
 	require.Equal(t, 1, stats1.ScheduledExecutions)
-	require.Equal(t, 1, stats1.ManualExecutions)
+	require.Equal(t, 2, stats1.ManualExecutions)
 	require.Equal(t, 1, stats1.CIExecutions)
 	require.ElementsMatch(
 		t,
-		[]string{"usera-s-organization/runner-android", "usera-s-organization/runner-ios"},
+		[]string{
+			"usera-s-organization/runner-android",
+			"usera-s-organization/runner-ios",
+			"usera-s-organization/runner-default",
+		},
 		stats1.Runners,
 	)
-	require.Equal(t, "1m45s", stats1.MinExecutionTime)
+	require.Equal(t, "5s", stats1.MinExecutionTime)
 	expectedFirstTime := exec1.Info.GetStartTime().AsTime()
 	actualFirstTime, err := time.Parse(time.RFC3339Nano, stats1.FirstExecutionDate)
 	require.NoError(t, err)
 	require.WithinDuration(t, expectedFirstTime, actualFirstTime, time.Second)
-	expectedLastTime := exec3.Info.GetStartTime().AsTime()
+	expectedLastTime := exec6.Info.GetStartTime().AsTime()
 	actualLastTime, err := time.Parse(time.RFC3339Nano, stats1.LastExecutionDate)
 	require.NoError(t, err)
 	require.WithinDuration(t, expectedLastTime, actualLastTime, time.Second)
-	require.Equal(t, 66.67, stats1.SuccessRate)
+	require.Equal(t, 75.00, stats1.SuccessRate)
 
 	require.NotNil(t, stats1.LastSuccessfulRun, "LastSuccessfulRun should not be nil")
-	require.Equal(t, "wf-2", stats1.LastSuccessfulRun.WorkflowID)
-	require.Equal(t, "run-2", stats1.LastSuccessfulRun.RunID)
-	require.NotEmpty(t, stats1.LastSuccessfulRun.StartTime)
+	require.Equal(t, "wf-6", stats1.LastSuccessfulRun.WorkflowID)
+	require.Equal(t, "run-6", stats1.LastSuccessfulRun.RunID)
 
 	require.NotNil(t, stats2)
 	require.Equal(t, 1, stats2.TotalRuns)
@@ -468,13 +470,7 @@ func TestHandleGetPipelineScoreboard(t *testing.T) {
 	require.Equal(t, "Pipeline-Sched-wf-4", stats2.LastSuccessfulRun.WorkflowID)
 	require.Equal(t, "run-4", stats2.LastSuccessfulRun.RunID)
 
-	require.Equal(t, "2h4m10s", stats3.MinExecutionTime)
-	require.NotNil(t, stats3.LastSuccessfulRun, "LastSuccessfulRun should not be nil")
-	require.Equal(t, "wf-5", stats3.LastSuccessfulRun.WorkflowID)
-	require.Equal(t, "run-5", stats3.LastSuccessfulRun.RunID)
-	require.Equal(t, 1, stats3.ManualExecutions)
-	require.Equal(t, 0, stats3.ScheduledExecutions)
-	require.Equal(t, 0, stats3.CIExecutions)
+	require.Nil(t, stats3, "unpublished pipelines must not appear on the scoreboard")
 
 	mockClient.AssertExpectations(t)
 }
@@ -815,25 +811,10 @@ func buildPipelineExecutionInfoWithRunner(
 			IndexedFields: indexedFields,
 		}
 	}
-	setWorkflowExecutionPublished(t, info, true)
 
 	return ExecutionInfo{
 		Info:     info,
 		Duration: duration,
-	}
-}
-
-func setWorkflowExecutionPublished(
-	t testing.TB,
-	info *workflow.WorkflowExecutionInfo,
-	published bool,
-) {
-	payload, err := converter.GetDefaultDataConverter().ToPayload(published)
-	require.NoError(t, err)
-	info.Memo = &common.Memo{
-		Fields: map[string]*common.Payload{
-			pipelineinternal.PublishedMemoKey: payload,
-		},
 	}
 }
 

--- a/pkg/internal/pipeline/run_types.go
+++ b/pkg/internal/pipeline/run_types.go
@@ -7,9 +7,6 @@ package pipeline
 const (
 	// RunTypeMemoKey carries the pipeline run type through Temporal memo.
 	RunTypeMemoKey = "pipeline_run_type"
-	// PublishedMemoKey carries the pipeline published state at run start.
-	PublishedMemoKey = "published"
-
 	// RunTypeManual marks runs started directly by a user.
 	RunTypeManual = "manual"
 	// RunTypeScheduled marks runs started by a Temporal schedule.

--- a/pkg/workflowengine/registry/registry_test.go
+++ b/pkg/workflowengine/registry/registry_test.go
@@ -33,7 +33,6 @@ func TestRegistryContainsCoreTasks(t *testing.T) {
 	require.NotNil(t, mobileTask.PayloadType)
 	require.False(t, mobileTask.CustomTaskQueue)
 	require.NotNil(t, mobileTask.PipelinePayloadType)
-
 }
 
 func TestRegistryFactoriesCreateInstances(t *testing.T) {

--- a/pkg/workflowengine/workflows/mobile_stub_test.go
+++ b/pkg/workflowengine/workflows/mobile_stub_test.go
@@ -32,6 +32,14 @@ func TestMobileAutomationWorkflowDisabled(t *testing.T) {
 	require.Contains(t, err.Error(), errorcodes.Codes[errorcodes.MissingOrInvalidConfig].Code)
 	failure := workflowengine.ParseWorkflowError(err)
 	require.Equal(t, errorcodes.Codes[errorcodes.MissingOrInvalidConfig].Code, failure.Code)
-	require.Equal(t, errorcodes.Codes[errorcodes.MissingOrInvalidConfig].Description, failure.Summary)
-	require.Equal(t, "mobile automation is disabled; build with -tags=credimi_extra", failure.Message)
+	require.Equal(
+		t,
+		errorcodes.Codes[errorcodes.MissingOrInvalidConfig].Description,
+		failure.Summary,
+	)
+	require.Equal(
+		t,
+		"mobile automation is disabled; build with -tags=credimi_extra",
+		failure.Message,
+	)
 }

--- a/pkg/workflowengine/workflows/scheduled_pipeline_enqueue.go
+++ b/pkg/workflowengine/workflows/scheduled_pipeline_enqueue.go
@@ -290,9 +290,8 @@ func (w *ScheduledPipelineEnqueueWorkflow) ExecuteWorkflow(
 		info.WorkflowExecution.RunID,
 	)
 	memo := map[string]any{
-		"test":                            "pipeline-run",
-		pipelineinternal.RunTypeMemoKey:   pipelineinternal.RunTypeScheduled,
-		pipelineinternal.PublishedMemoKey: scheduledPipelinePublished(record),
+		"test":                          "pipeline-run",
+		pipelineinternal.RunTypeMemoKey: pipelineinternal.RunTypeScheduled,
 	}
 
 	enqueueInput := workflowengine.ActivityInput{
@@ -409,11 +408,6 @@ type scheduledPipelineStep struct {
 type scheduledPipelineRunnerInfo struct {
 	RunnerIDs         []string
 	NeedsGlobalRunner bool
-}
-
-func scheduledPipelinePublished(record map[string]any) bool {
-	published, _ := record[pipelineinternal.PublishedMemoKey].(bool)
-	return published
 }
 
 // parseScheduledPipelineDefinition reads YAML and returns runner metadata for schedules.

--- a/pkg/workflowengine/workflows/scheduled_pipeline_enqueue_test.go
+++ b/pkg/workflowengine/workflows/scheduled_pipeline_enqueue_test.go
@@ -116,7 +116,6 @@ steps:
 		pipelineinternal.RunTypeScheduled,
 		capturedPayload.Memo[pipelineinternal.RunTypeMemoKey],
 	)
-	require.Equal(t, true, capturedPayload.Memo[pipelineinternal.PublishedMemoKey])
 
 	require.False(t, capturedPayload.EnqueuedAt.IsZero())
 	require.Equal(t, time.UTC, capturedPayload.EnqueuedAt.Location())


### PR DESCRIPTION
## Problem

The public scoreboard did not show `fcaf-1/fcaf-wallet-relying-party-demo-validation` even though the pipeline is published. Production evidence: the pipeline was published on 31/08/2026 09:33, the scoreboard cache was fully rebuilt at 15:25 the same day, and the pipeline still had no `pipeline_scoreboard_cache` row — its executions were being dropped at the per-namespace visibility gate.

## Root cause

Each queued/scheduled run wrote a `published` memo snapshot on the Temporal execution, and `HandleGetPipelineScoreboard` let that snapshot override the pipeline record forever:

- a run started while the pipeline was unpublished carried `published=false` and stayed invisible **even after the pipeline was published** (the reported case);
- conversely, an unpublished pipeline kept showing on the public scoreboard while its older runs carried `published=true`.

Direct runs never wrote the memo at all and fell back to the record state, so behavior also differed by run path.

## Fix

Scoreboard visibility now follows the pipeline record's **current** `published` flag in both directions:

- publish later → runs appear on the next aggregate run;
- unpublish → pipeline disappears again.

Clean cutover of the dead machinery: removed the `PublishedMemoKey` memo writes (queue handler, scheduled enqueue), the constant, the memo-reading helpers, and stale test assertions. `TestHandleGetPipelineScoreboard` now covers both cases: pre-publish run + published pipeline → included; unpublished pipeline → excluded.

## Validation

- `go test -tags=unit` for `pkg/internal/apis/handlers`, `pkg/workflowengine/workflows`, `pkg/internal/pipeline` — pass
- `make fmt`, `go mod tidy -diff`, `go mod verify`, `go vet` — clean
- `golangci-lint` on touched packages — 0 issues (`make lint` failure references a nonexistent `../fcaf-hub` path, stale-cache bleed, pre-existing)
- `revive` — only pre-existing exported-comment nits on untouched lines