### PR TITLE
fix(fcaf): per-test report evidence and wallet action steps

### DIFF
--- a/cmd/cli/fcaf.go
+++ b/cmd/cli/fcaf.go
@@ -706,12 +706,10 @@ func syncFCAFWalletAction(
 		category = "other"
 	}
 	updates := map[string]any{
-		"name":     action.Name,
-		"code":     code,
-		"category": category,
-	}
-	if action.Tags != "" {
-		updates["tags"] = action.Tags
+		"name":      action.Name,
+		"code":      code,
+		"category":  category,
+		"published": true,
 	}
 	switch len(records) {
 	case 0:

--- a/cmd/fcaf-pipeline-gen/main.go
+++ b/cmd/fcaf-pipeline-gen/main.go
@@ -35,8 +35,9 @@ type aggregateDefinition struct {
 var nonSlugCharacter = regexp.MustCompile(`[^a-z0-9]+`)
 
 const (
-	completeValidationName = "FCAF wallet relying-party complete validation"
-	demoValidationName     = "FCAF wallet relying-party demo validation"
+	completeValidationName  = "FCAF wallet relying-party complete validation"
+	demoValidationName      = "FCAF wallet relying-party demo validation"
+	happyFlowValidationName = "FCAF wallet relying-party happy flow validation"
 )
 
 var demoScenarioNames = []string{
@@ -109,6 +110,11 @@ func main() {
 		"config_templates/fcaf/wallet_solution/relying_party/pipelines/fcaf-wallet-solution-relying-party-demo-validation.yaml",
 		"generated demo validation pipeline YAML",
 	)
+	happyFlowOutputPath := flag.String(
+		"happy-flow-output",
+		"config_templates/fcaf/wallet_solution/relying_party/pipelines/fcaf-wallet-solution-relying-party-happy-flow-validation.yaml",
+		"generated happy flow validation pipeline YAML",
+	)
 	flag.Parse()
 
 	if err := generate(*inputDir, *outputPath); err != nil {
@@ -119,31 +125,73 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	if err := generateHappyFlow(*inputDir, *happyFlowOutputPath); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }
 
 func generateDemo(inputDir string, outputPath string) error {
+	selected, err := selectScenarios(inputDir, demoScenarioNames)
+	if err != nil {
+		return err
+	}
+	return buildAggregate(demoValidationName, selected, outputPath, demoTestIDs)
+}
+
+// happyFlowScenarioNames keeps the happy flow to the shared-evidence
+// scenarios that own the positive test batches; the fragmented one-test
+// DCQL variants stay in the complete validation aggregate only.
+var happyFlowScenarioNames = []string{
+	"fcaf-wallet-solution-relying-party-engagement-haip-vp.yaml",
+	"fcaf-wallet-solution-relying-party-pid-mdoc-data-model.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-protocol-messages.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-metadata.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-main-interaction.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-rp-integrity.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-credential-formats.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-trust-mechanisms.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-session-encryption.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-interaction-metadata.yaml",
+	"fcaf-wallet-solution-relying-party-request-object-by-value.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-cryptography.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-credentials-match.yaml",
+	"fcaf-wallet-solution-relying-party-dcql-device-binding.yaml",
+}
+
+// generateHappyFlow builds the aggregate pipeline validating every FCAF test
+// owned by the single happy-flow scenario, without the curated demo filter.
+func generateHappyFlow(inputDir string, outputPath string) error {
+	selected, err := selectScenarios(inputDir, happyFlowScenarioNames)
+	if err != nil {
+		return err
+	}
+	return buildAggregate(happyFlowValidationName, selected, outputPath, nil)
+}
+
+func selectScenarios(inputDir string, names []string) ([]string, error) {
 	paths, err := filepath.Glob(filepath.Join(inputDir, "*.yaml"))
 	if err != nil {
-		return fmt.Errorf("find FCAF scenarios: %w", err)
+		return nil, fmt.Errorf("find FCAF scenarios: %w", err)
 	}
-	selected := make([]string, 0, len(demoScenarioNames))
+	selected := make([]string, 0, len(names))
 	for _, path := range paths {
-		for _, name := range demoScenarioNames {
+		for _, name := range names {
 			if filepath.Base(path) == name {
 				selected = append(selected, path)
 				break
 			}
 		}
 	}
-	if len(selected) != len(demoScenarioNames) {
-		return fmt.Errorf(
-			"demo scenarios incomplete: expected %v, found %d files",
-			demoScenarioNames,
+	if len(selected) != len(names) {
+		return nil, fmt.Errorf(
+			"FCAF scenarios incomplete: expected %v, found %d files",
+			names,
 			len(selected),
 		)
 	}
 	sort.Strings(selected)
-	return buildAggregate(demoValidationName, selected, outputPath, demoTestIDs)
+	return selected, nil
 }
 
 func generate(inputDir string, outputPath string) error {

--- a/cmd/fcaf-pipeline-gen/main_test.go
+++ b/cmd/fcaf-pipeline-gen/main_test.go
@@ -94,3 +94,48 @@ func TestGenerateDemoFCAFPipeline(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, committed, data, "generated demo pipeline is stale")
 }
+
+func TestGenerateHappyFlowFCAFPipeline(t *testing.T) {
+	root := filepath.Join(
+		"..",
+		"..",
+		"config_templates",
+		"fcaf",
+		"wallet_solution",
+		"relying_party",
+	)
+	output := filepath.Join(t.TempDir(), "happy-flow.yaml")
+	require.NoError(t, generateHappyFlow(filepath.Join(root, "scenarios"), output))
+
+	data, err := os.ReadFile(output)
+	require.NoError(t, err)
+	var definition pipelineDefinition
+	require.NoError(t, yaml.Unmarshal(data, &definition))
+	require.Len(t, definition.Steps, 53)
+	require.Equal(t, "onboard-reference-wallet", definition.Steps[0]["id"])
+
+	validationSteps := make([]map[string]any, 0, 1)
+	for index, step := range definition.Steps {
+		if step["use"] == validationTask {
+			validationSteps = append(validationSteps, step)
+			continue
+		}
+		if step["id"] == "onboard-reference-wallet" {
+			continue
+		}
+		require.Equal(t, true, step["continue_on_error"], "step %d", index)
+	}
+	require.Len(t, validationSteps, 1)
+	with, ok := validationSteps[0]["with"].(map[string]any)
+	require.True(t, ok)
+	require.Len(t, stringSlice(with["test_ids"]), 423)
+	require.Len(t, with["pipeline_outputs"], 17)
+
+	committed, err := os.ReadFile(filepath.Join(
+		root,
+		"pipelines",
+		"fcaf-wallet-solution-relying-party-happy-flow-validation.yaml",
+	))
+	require.NoError(t, err)
+	require.Equal(t, committed, data, "generated happy flow pipeline is stale")
+}

--- a/config_templates/fcaf/imports/forkbomb-bv-andrea/wallet-actions.yaml
+++ b/config_templates/fcaf/imports/forkbomb-bv-andrea/wallet-actions.yaml
@@ -30,3 +30,11 @@ actions:
     category: verify-credential
     tags: fcaf, engagement, haip-vp
     file: wallet/fcaf-engagement-haip-vp.yaml
+  - name: fcaf-exercise-wallet-generic
+    category: verify-credential
+    tags: fcaf, exercise, generic
+    file: wallet/fcaf-exercise-wallet-generic.yaml
+  - name: fcaf-submit-request-object-by-value
+    category: verify-credential
+    tags: fcaf, request-object, by-value
+    file: wallet/fcaf-submit-request-object-by-value.yaml

--- a/config_templates/fcaf/imports/forkbomb-bv-andrea/wallet/fcaf-exercise-wallet-generic.yaml
+++ b/config_templates/fcaf/imports/forkbomb-bv-andrea/wallet/fcaf-exercise-wallet-generic.yaml
@@ -1,0 +1,86 @@
+appId: eu.europa.ec.euidi
+name: FCAF exercise wallet - generic capture session flow
+tags:
+  - fcaf
+  - exercise
+  - generic
+---
+- launchApp:
+    stopApp: true
+    clearState: false
+    permissions:
+      camera: allow
+      notifications: allow
+      all: unset
+- extendedWaitUntil:
+    visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
+    timeout: 30000
+- runFlow:
+    when:
+      visible: "Welcome back"
+    commands:
+      - tapOn:
+          point: "11%,40%"
+      - inputText: "123456"
+      - hideKeyboard
+      - tapOn:
+          point: "50%,10%"
+- extendedWaitUntil:
+    visible: "Home|Documents|Add document|Welcome, .*"
+    timeout: 30000
+- openLink:
+    link: "${deeplink}"
+    autoVerify: false
+    browser: false
+- runFlow:
+    when:
+      visible: "EUDI Wallet"
+    commands:
+      - tapOn:
+          text: "EUDI Wallet"
+          optional: true
+- runFlow:
+    when:
+      visible: "Just once"
+    commands:
+      - tapOn:
+          text: "Just once"
+          optional: true
+- runFlow:
+    when:
+      visible: "Always"
+    commands:
+      - tapOn:
+          text: "Always"
+          optional: true
+- extendedWaitUntil:
+    visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
+    timeout: 100000
+- runFlow:
+    when:
+      visible: "DATA SHARING REQUEST"
+    commands:
+      - tapOn: "Share"
+      - extendedWaitUntil:
+          visible: "PIN"
+          timeout: 30000
+      - tapOn:
+          point: "11%,39%"
+      - inputText: "123456"
+      - tapOn:
+          point: "50%,10%"
+      - extendedWaitUntil:
+          visible: ".*successfully shared.*|Welcome back"
+          timeout: 30000
+- runFlow:
+    when:
+      visible: "Welcome back"
+    commands:
+      - tapOn:
+          point: "11%,40%"
+      - inputText: "123456"
+- extendedWaitUntil:
+    visible: "Error|invalid request|Something went wrong|Home|Documents"
+    timeout: 30000
+- takeScreenshot: exercise-wallet
+- back

--- a/config_templates/fcaf/imports/forkbomb-bv-andrea/wallet/fcaf-submit-request-object-by-value.yaml
+++ b/config_templates/fcaf/imports/forkbomb-bv-andrea/wallet/fcaf-submit-request-object-by-value.yaml
@@ -1,0 +1,46 @@
+appId: eu.europa.ec.euidi
+name: FCAF submit request object by value
+tags:
+  - fcaf
+  - request-object
+  - by-value
+---
+- stopApp
+- evalScript: ${output.authorizationRequest = 'haip-vp://?client_id=' + encodeURIComponent(env.CLIENT_ID) + '&request=' + encodeURIComponent(env.REQUEST_OBJECT)}
+- openLink:
+    link: ${output.authorizationRequest}
+    autoVerify: false
+    browser: false
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn:
+    text: "EUDI Wallet"
+    optional: true
+- tapOn:
+    text: "Just once"
+    optional: true
+- extendedWaitUntil:
+    visible: "Welcome back|Share|Cancel|Close"
+    timeout: 100000
+- runFlow:
+    when:
+      visible: "Welcome back"
+    commands:
+      - tapOn:
+          point: "11%,40%"
+      - inputText: "123456"
+- extendedWaitUntil:
+    visible: "Share"
+    timeout: 30000
+- tapOn:
+    text: "Share"
+    enabled: true
+- extendedWaitUntil:
+    visible: "verify your identity|PIN"
+    timeout: 30000
+- inputText: "123456"
+- extendedWaitUntil:
+    visible: "Close"
+    timeout: 30000
+- assertVisible: "Close"
+- takeScreenshot: fcaf-request-object-by-value-accepted

--- a/config_templates/fcaf/wallet_solution/relying_party/pipelines/fcaf-wallet-solution-relying-party-complete-validation.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/pipelines/fcaf-wallet-solution-relying-party-complete-validation.yaml
@@ -1031,90 +1031,9 @@ steps:
       id: dcql-credential-formats-3cfeac03-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: credential-formats
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-credential-formats-3cfeac03-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-credential-formats-3cfeac03-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-credential-formats-3cfeac03-fetch-capture-session
@@ -1931,90 +1850,9 @@ steps:
       id: dcql-cryptography-1a488a33-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: cryptography
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-cryptography-1a488a33-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-cryptography-1a488a33-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-cryptography-1a488a33-fetch-capture-session
@@ -2054,90 +1892,9 @@ steps:
       id: dcql-device-binding-f7c71f86-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: device-binding
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-device-binding-f7c71f86-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-device-binding-f7c71f86-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-device-binding-f7c71f86-fetch-capture-session
@@ -3180,90 +2937,9 @@ steps:
       id: dcql-interaction-metadata-f9737358-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: interaction-metadata
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-interaction-metadata-f9737358-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-interaction-metadata-f9737358-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-interaction-metadata-f9737358-fetch-capture-session
@@ -3781,90 +3457,9 @@ steps:
       id: dcql-main-interaction-eeb8ef1f-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: main-interaction
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-main-interaction-eeb8ef1f-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-main-interaction-eeb8ef1f-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-main-interaction-eeb8ef1f-fetch-capture-session
@@ -3966,90 +3561,9 @@ steps:
       id: dcql-metadata-b66a6319-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: metadata
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-metadata-b66a6319-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-metadata-b66a6319-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-metadata-b66a6319-fetch-capture-session
@@ -8935,90 +8449,9 @@ steps:
       id: dcql-protocol-messages-a25772b2-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: protocol-messages
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-protocol-messages-a25772b2-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-protocol-messages-a25772b2-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-protocol-messages-a25772b2-fetch-capture-session
@@ -9058,90 +8491,9 @@ steps:
       id: dcql-rp-integrity-3576cc79-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: rp-integrity
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-rp-integrity-3576cc79-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-rp-integrity-3576cc79-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-rp-integrity-3576cc79-fetch-capture-session
@@ -9375,90 +8727,9 @@ steps:
       id: dcql-session-encryption-210827bd-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: session-encryption
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-session-encryption-210827bd-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-session-encryption-210827bd-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-session-encryption-210827bd-fetch-capture-session
@@ -9561,90 +8832,9 @@ steps:
       id: dcql-trust-mechanisms-157d0f39-exercise-wallet
       use: mobile-automation
       with:
-        action_code: |-
-            appId: eu.europa.ec.euidi
-            ---
-            - launchApp:
-                stopApp: true
-                clearState: false
-                permissions:
-                  camera: allow
-                  notifications: allow
-                  all: unset
-            - extendedWaitUntil:
-                visible: "Welcome back|Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-                  - hideKeyboard
-                  - tapOn:
-                      point: "50%,10%"
-            - extendedWaitUntil:
-                visible: "Home|Documents|Add document|Welcome, .*"
-                timeout: 30000
-            - openLink:
-                link: "${DEEPLINK}"
-                autoVerify: false
-                browser: false
-            - runFlow:
-                when:
-                  visible: "EUDI Wallet"
-                commands:
-                  - tapOn:
-                      text: "EUDI Wallet"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Just once"
-                commands:
-                  - tapOn:
-                      text: "Just once"
-                      optional: true
-            - runFlow:
-                when:
-                  visible: "Always"
-                commands:
-                  - tapOn:
-                      text: "Always"
-                      optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Error|invalid request|Something went wrong|DATA SHARING REQUEST"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "DATA SHARING REQUEST"
-                commands:
-                  - tapOn: "Share"
-                  - extendedWaitUntil:
-                      visible: "PIN"
-                      timeout: 30000
-                  - tapOn:
-                      point: "11%,39%"
-                  - inputText: "123456"
-                  - tapOn:
-                      point: "50%,10%"
-                  - extendedWaitUntil:
-                      visible: ".*successfully shared.*|Welcome back"
-                      timeout: 30000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Error|invalid request|Something went wrong|Home|Documents"
-                timeout: 30000
-            - takeScreenshot: trust-mechanisms
-            - back
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
         parameters:
-            DEEPLINK: ${{ dcql-trust-mechanisms-157d0f39-create-capture-session.outputs.body.deeplink }}
+            deeplink: ${{ dcql-trust-mechanisms-157d0f39-create-capture-session.outputs.body.deeplink }}
         version_id: installed_from_external_source
     - continue_on_error: true
       id: dcql-trust-mechanisms-157d0f39-fetch-capture-session
@@ -11349,48 +10539,7 @@ steps:
       id: request-object-by-value-f1c94061-submit-request-object-by-value
       use: mobile-automation
       with:
-        action_code: |
-            appId: eu.europa.ec.euidi
-            ---
-            - stopApp
-            - evalScript: ${output.authorizationRequest = 'haip-vp://?client_id=' + encodeURIComponent(env.CLIENT_ID) + '&request=' + encodeURIComponent(env.REQUEST_OBJECT)}
-            - openLink:
-                link: ${output.authorizationRequest}
-                autoVerify: false
-                browser: false
-            - waitForAnimationToEnd:
-                timeout: 5000
-            - tapOn:
-                text: "EUDI Wallet"
-                optional: true
-            - tapOn:
-                text: "Just once"
-                optional: true
-            - extendedWaitUntil:
-                visible: "Welcome back|Share|Cancel|Close"
-                timeout: 100000
-            - runFlow:
-                when:
-                  visible: "Welcome back"
-                commands:
-                  - tapOn:
-                      point: "11%,40%"
-                  - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Share"
-                timeout: 30000
-            - tapOn:
-                text: "Share"
-                enabled: true
-            - extendedWaitUntil:
-                visible: "verify your identity|PIN"
-                timeout: 30000
-            - inputText: "123456"
-            - extendedWaitUntil:
-                visible: "Close"
-                timeout: 30000
-            - assertVisible: "Close"
-            - takeScreenshot: fcaf-request-object-by-value-accepted
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-submit-request-object-by-value
         parameters:
             CLIENT_ID: ${{ request-object-by-value-f1c94061-create-presentation.outputs.body.client_id }}
             REQUEST_OBJECT: ${{ request-object-by-value-f1c94061-create-presentation.outputs.body.request }}

--- a/config_templates/fcaf/wallet_solution/relying_party/pipelines/fcaf-wallet-solution-relying-party-happy-flow-validation.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/pipelines/fcaf-wallet-solution-relying-party-happy-flow-validation.yaml
@@ -1,0 +1,1334 @@
+name: FCAF wallet relying-party happy flow validation
+runtime:
+    global_runner_id: forkbomb-bv-andrea/usb
+    temporal:
+        activity_options:
+            heartbeat_timeout: 10m
+            retry_policy:
+                maximum_attempts: 1
+            schedule_to_close_timeout: 50m
+            start_to_close_timeout: 50m
+steps:
+    - id: onboard-reference-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/onboarding-1
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: dcql-credential-formats-3cfeac03-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: credential-formats
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-credential-formats-3cfeac03-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-credential-formats-3cfeac03-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-credential-formats-3cfeac03-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-credential-formats-3cfeac03-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-credentials-match-cc301c32-onboard-reference-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/onboarding-1
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: dcql-credentials-match-cc301c32-create-pid-sdjwt-offer
+      use: credential-offer
+      with:
+        credential_id: /forkbomb-bv-andrea/misc-issuer-integration-demo/capture-issuer-pid-dc-sd-jwt
+    - continue_on_error: true
+      id: dcql-credentials-match-cc301c32-obtain-pid-sdjwt
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/getcredential-generic-credential-without-authentication
+        parameters:
+            deeplink: ${{ dcql-credentials-match-cc301c32-create-pid-sdjwt-offer.outputs }}
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - activity_options:
+        retry_policy:
+            backoff_coefficient: 2
+            initial_interval: 5s
+            maximum_attempts: 3
+            maximum_interval: 30s
+        start_to_close_timeout: 2m
+      continue_on_error: true
+      id: dcql-credentials-match-cc301c32-create-presentation
+      use: http-request
+      with:
+        body:
+            dcql_query:
+                credentials:
+                    - claims:
+                        - path:
+                            - given_name
+                        - path:
+                            - family_name
+                      format: dc+sd-jwt
+                      id: pid_identity
+                      meta:
+                        vct_values:
+                            - urn:eudi:pid:1
+            nonce: fcaf-dcql-credentials-match
+            type: vp_token
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-credentials-match-cc301c32-present-with-reference-implementation
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-engagement-haip-vp
+        parameters:
+            deeplink: ${{ dcql-credentials-match-cc301c32-create-presentation.outputs.body.deeplink }}
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - activity_options:
+        retry_policy:
+            backoff_coefficient: 2
+            initial_interval: 5s
+            maximum_attempts: 3
+            maximum_interval: 30s
+        start_to_close_timeout: 2m
+      continue_on_error: true
+      id: dcql-credentials-match-cc301c32-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-credentials-match-cc301c32-create-presentation.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-cryptography-1a488a33-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: cryptography
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-cryptography-1a488a33-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-cryptography-1a488a33-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-cryptography-1a488a33-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-cryptography-1a488a33-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-device-binding-f7c71f86-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: device-binding
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-device-binding-f7c71f86-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-device-binding-f7c71f86-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-device-binding-f7c71f86-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-device-binding-f7c71f86-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-interaction-metadata-f9737358-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: interaction-metadata
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-interaction-metadata-f9737358-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-interaction-metadata-f9737358-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-interaction-metadata-f9737358-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-interaction-metadata-f9737358-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-main-interaction-eeb8ef1f-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: main-interaction
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-main-interaction-eeb8ef1f-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-main-interaction-eeb8ef1f-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-main-interaction-eeb8ef1f-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-main-interaction-eeb8ef1f-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-metadata-b66a6319-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: metadata
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-metadata-b66a6319-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-metadata-b66a6319-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-metadata-b66a6319-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-metadata-b66a6319-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-protocol-messages-a25772b2-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: protocol-messages
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-protocol-messages-a25772b2-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-protocol-messages-a25772b2-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-protocol-messages-a25772b2-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-protocol-messages-a25772b2-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-rp-integrity-3576cc79-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: rp-integrity
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-rp-integrity-3576cc79-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-rp-integrity-3576cc79-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-rp-integrity-3576cc79-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-rp-integrity-3576cc79-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-session-encryption-210827bd-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: session-encryption
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-session-encryption-210827bd-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-session-encryption-210827bd-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-session-encryption-210827bd-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-session-encryption-210827bd-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: dcql-trust-mechanisms-157d0f39-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                          format: dc+sd-jwt
+                          id: pid
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: trust-mechanisms
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: dcql-trust-mechanisms-157d0f39-exercise-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
+        parameters:
+            deeplink: ${{ dcql-trust-mechanisms-157d0f39-create-capture-session.outputs.body.deeplink }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: dcql-trust-mechanisms-157d0f39-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ dcql-trust-mechanisms-157d0f39-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: engagement-haip-vp-4bb0f83a-onboard-reference-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/onboarding-1
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: engagement-haip-vp-4bb0f83a-create-pid-sdjwt-offer
+      use: credential-offer
+      with:
+        credential_id: /forkbomb-bv-andrea/misc-issuer-integration-demo/capture-issuer-pid-dc-sd-jwt
+    - continue_on_error: true
+      id: engagement-haip-vp-4bb0f83a-obtain-pid-sdjwt
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/getcredential-generic-credential-without-authentication
+        parameters:
+            deeplink: ${{ engagement-haip-vp-4bb0f83a-create-pid-sdjwt-offer.outputs }}
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: engagement-haip-vp-4bb0f83a-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - given_name
+                            - path:
+                                - family_name
+                            - path:
+                                - address
+                                - country
+                            - path:
+                                - address
+                                - formatted
+                            - path:
+                                - address
+                                - house_number
+                            - path:
+                                - address
+                                - locality
+                            - path:
+                                - address
+                                - postal_code
+                            - path:
+                                - address
+                                - region
+                            - path:
+                                - address
+                                - street_address
+                            - path:
+                                - birth_family_name
+                            - path:
+                                - birth_given_name
+                            - path:
+                                - birthdate
+                            - path:
+                                - date_of_expiry
+                            - path:
+                                - date_of_issuance
+                            - path:
+                                - document_number
+                            - path:
+                                - email
+                            - path:
+                                - issuing_authority
+                            - path:
+                                - issuing_country
+                            - path:
+                                - issuing_jurisdiction
+                            - path:
+                                - nationalities
+                            - path:
+                                - personal_administrative_number
+                            - path:
+                                - phone_number
+                            - path:
+                                - picture
+                            - path:
+                                - place_of_birth
+                            - path:
+                                - sex
+                          format: dc+sd-jwt
+                          id: pid_sdjwt
+                          meta:
+                            vct_values:
+                                - urn:eudi:pid:1
+                nonce: fcaf-engagement-haip-vp
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-engagement-haip-vp
+        parameters:
+            deeplink: ${{ engagement-haip-vp-4bb0f83a-create-capture-session.outputs.body.deeplink }}
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: engagement-haip-vp-4bb0f83a-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ engagement-haip-vp-4bb0f83a-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: pid-mdoc-data-model-8f915369-onboard-reference-wallet
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/onboarding-1
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: pid-mdoc-data-model-8f915369-create-pid-mdoc-offer
+      use: credential-offer
+      with:
+        credential_id: /forkbomb-bv-andrea/misc-issuer-integration-demo/capture-issuer-pid-mdoc
+    - continue_on_error: true
+      id: pid-mdoc-data-model-8f915369-obtain-pid-mdoc
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/getcredential-generic-credential-without-authentication
+        parameters:
+            deeplink: ${{ pid-mdoc-data-model-8f915369-create-pid-mdoc-offer.outputs }}
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: pid-mdoc-data-model-8f915369-create-capture-session
+      use: http-request
+      with:
+        body:
+            presentation_request:
+                dcql_query:
+                    credentials:
+                        - claims:
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - birth_date
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - document_number
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - email_address
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - expiry_date
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - family_name
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - family_name_birth
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - given_name
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - given_name_birth
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - issuance_date
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - issuing_authority
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - issuing_country
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - issuing_jurisdiction
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - mobile_phone_number
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - nationality
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - personal_administrative_number
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - place_of_birth
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - portrait
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_address
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_city
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_country
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_house_number
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_postal_code
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_state
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - resident_street
+                            - path:
+                                - eu.europa.ec.eudi.pid.1
+                                - sex
+                          format: mso_mdoc
+                          id: pid_mdoc
+                          meta:
+                            doctype_value: eu.europa.ec.eudi.pid.1
+                nonce: fcaf-pid-mdoc-data-model
+            request_delivery: by_reference
+            request_uri_method: post
+            response_mode: direct_post
+            response_type: vp_token
+            scheme: haip-vp://
+        expected_status: 201
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: https://capture-wallet.credimi.io/openid4vp/sessions
+    - continue_on_error: true
+      id: pid-mdoc-data-model-8f915369-invoke-wallet-with-haip-vp
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-engagement-haip-vp
+        parameters:
+            deeplink: ${{ pid-mdoc-data-model-8f915369-create-capture-session.outputs.body.deeplink }}
+        version_id: forkbomb-bv-andrea/eudiw-beta-wallet/2026-06-38-demo
+    - continue_on_error: true
+      id: pid-mdoc-data-model-8f915369-fetch-capture-session
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: https://capture-wallet.credimi.io/openid4vp/sessions/${{ pid-mdoc-data-model-8f915369-create-capture-session.outputs.body.session_id }}
+    - continue_on_error: true
+      id: request-object-by-value-f1c94061-create-presentation
+      use: http-request
+      with:
+        body:
+            dcql_query:
+                credentials:
+                    - claims:
+                        - path:
+                            - eu.europa.ec.eudi.pid.1
+                            - given_name
+                        - path:
+                            - eu.europa.ec.eudi.pid.1
+                            - family_name
+                      format: mso_mdoc
+                      id: pid_mdoc
+                      meta:
+                        doctype_value: eu.europa.ec.eudi.pid.1
+            jar_mode: by_value
+            nonce: fcaf-request-object-by-value
+            type: vp_token
+        expected_status: 200
+        headers:
+            Content-Type: application/json
+        method: POST
+        url: ${fixture.verifier_url}/ui/presentations
+    - continue_on_error: true
+      id: request-object-by-value-f1c94061-submit-request-object-by-value
+      use: mobile-automation
+      with:
+        action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-submit-request-object-by-value
+        parameters:
+            CLIENT_ID: ${{ request-object-by-value-f1c94061-create-presentation.outputs.body.client_id }}
+            REQUEST_OBJECT: ${{ request-object-by-value-f1c94061-create-presentation.outputs.body.request }}
+        version_id: installed_from_external_source
+    - continue_on_error: true
+      id: request-object-by-value-f1c94061-get-presentation-result
+      use: http-request
+      with:
+        expected_status: 200
+        method: GET
+        url: ${fixture.verifier_url}/ui/presentations/${{ request-object-by-value-f1c94061-create-presentation.outputs.body.transaction_id }}
+    - id: run-complete-fcaf-validation
+      use: fcaf-validation
+      with:
+        pipeline_outputs:
+            forkbomb-bv-andrea/fcaf-wallet-solution-relying-party-engagement-haip-vp:
+                output:
+                    create-capture-session: ${{ engagement-haip-vp-4bb0f83a-create-capture-session.outputs | optional }}
+                    create-pid-sdjwt-offer: ${{ engagement-haip-vp-4bb0f83a-create-pid-sdjwt-offer.outputs | optional }}
+                    fetch-capture-session: ${{ engagement-haip-vp-4bb0f83a-fetch-capture-session.outputs | optional }}
+                    invoke-wallet-with-haip-vp: ${{ engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp.outputs | optional }}
+                    obtain-pid-sdjwt: ${{ engagement-haip-vp-4bb0f83a-obtain-pid-sdjwt.outputs | optional }}
+                    onboard-reference-wallet: ${{ engagement-haip-vp-4bb0f83a-onboard-reference-wallet.outputs | optional }}
+                    visual_evidence: ${{ engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp.outputs.flow_output.maestro_screenshot_urls | optional }}
+            forkbomb-bv-andrea/fcaf-wallet-solution-relying-party-pid-mdoc-data-model:
+                output:
+                    create-capture-session: ${{ pid-mdoc-data-model-8f915369-create-capture-session.outputs | optional }}
+                    create-pid-mdoc-offer: ${{ pid-mdoc-data-model-8f915369-create-pid-mdoc-offer.outputs | optional }}
+                    fetch-capture-session: ${{ pid-mdoc-data-model-8f915369-fetch-capture-session.outputs | optional }}
+                    invoke-wallet-with-haip-vp: ${{ pid-mdoc-data-model-8f915369-invoke-wallet-with-haip-vp.outputs | optional }}
+                    obtain-pid-mdoc: ${{ pid-mdoc-data-model-8f915369-obtain-pid-mdoc.outputs | optional }}
+                    onboard-reference-wallet: ${{ pid-mdoc-data-model-8f915369-onboard-reference-wallet.outputs | optional }}
+                    visual_evidence: ${{ pid-mdoc-data-model-8f915369-invoke-wallet-with-haip-vp.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.credential-formats:
+                output:
+                    dcql_exchange: ${{ dcql-credential-formats-3cfeac03-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-credential-formats-3cfeac03-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.credentials-match:
+                output:
+                    create-presentation: ${{ dcql-credentials-match-cc301c32-create-presentation.outputs | optional }}
+                    dcql_exchange: ${{ dcql-credentials-match-cc301c32-fetch-capture-session.outputs.body | optional }}
+                    fetch-capture-session: ${{ dcql-credentials-match-cc301c32-fetch-capture-session.outputs | optional }}
+                    present-with-reference-implementation: ${{ dcql-credentials-match-cc301c32-present-with-reference-implementation.outputs | optional }}
+                    visual_evidence: ${{ dcql-credentials-match-cc301c32-present-with-reference-implementation.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.cryptography:
+                output:
+                    dcql_exchange: ${{ dcql-cryptography-1a488a33-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-cryptography-1a488a33-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.device-binding:
+                output:
+                    dcql_exchange: ${{ dcql-device-binding-f7c71f86-fetch-capture-session.outputs.body | optional }}
+                    pid_sdjwt_presentations: ${{ dcql-device-binding-f7c71f86-fetch-capture-session.outputs.body.observed.wallet_response.value.vp_token | optional }}
+                    visual_evidence: ${{ dcql-device-binding-f7c71f86-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.interaction-metadata:
+                output:
+                    dcql_exchange: ${{ dcql-interaction-metadata-f9737358-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-interaction-metadata-f9737358-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.main-interaction:
+                output:
+                    dcql_exchange: ${{ dcql-main-interaction-eeb8ef1f-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-main-interaction-eeb8ef1f-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.metadata:
+                output:
+                    dcql_exchange: ${{ dcql-metadata-b66a6319-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-metadata-b66a6319-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.protocol-messages:
+                output:
+                    dcql_exchange: ${{ dcql-protocol-messages-a25772b2-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-protocol-messages-a25772b2-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.rp-integrity:
+                output:
+                    dcql_exchange: ${{ dcql-rp-integrity-3576cc79-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-rp-integrity-3576cc79-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.session-encryption:
+                output:
+                    dcql_exchange: ${{ dcql-session-encryption-210827bd-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-session-encryption-210827bd-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.dcql.trust-mechanisms:
+                output:
+                    dcql_exchange: ${{ dcql-trust-mechanisms-157d0f39-fetch-capture-session.outputs.body | optional }}
+                    visual_evidence: ${{ dcql-trust-mechanisms-157d0f39-exercise-wallet.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.pid.presentation.mdoc.all-claims-elements:
+                output:
+                    create-capture-session: ${{ pid-mdoc-data-model-8f915369-create-capture-session.outputs | optional }}
+                    create-pid-mdoc-offer: ${{ pid-mdoc-data-model-8f915369-create-pid-mdoc-offer.outputs | optional }}
+                    fetch-capture-session: ${{ pid-mdoc-data-model-8f915369-fetch-capture-session.outputs | optional }}
+                    invoke-wallet-with-haip-vp: ${{ pid-mdoc-data-model-8f915369-invoke-wallet-with-haip-vp.outputs | optional }}
+                    obtain-pid-mdoc: ${{ pid-mdoc-data-model-8f915369-obtain-pid-mdoc.outputs | optional }}
+                    onboard-reference-wallet: ${{ pid-mdoc-data-model-8f915369-onboard-reference-wallet.outputs | optional }}
+                    pid_mdoc: ${{ pid-mdoc-data-model-8f915369-fetch-capture-session.outputs.body.observed.wallet_response.value.vp_token | optional }}
+                    visual_evidence: ${{ pid-mdoc-data-model-8f915369-invoke-wallet-with-haip-vp.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.pid.presentation.sdjwt.all-claims:
+                output:
+                    create-capture-session: ${{ engagement-haip-vp-4bb0f83a-create-capture-session.outputs | optional }}
+                    create-pid-sdjwt-offer: ${{ engagement-haip-vp-4bb0f83a-create-pid-sdjwt-offer.outputs | optional }}
+                    fetch-capture-session: ${{ engagement-haip-vp-4bb0f83a-fetch-capture-session.outputs | optional }}
+                    invoke-wallet-with-haip-vp: ${{ engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp.outputs | optional }}
+                    obtain-pid-sdjwt: ${{ engagement-haip-vp-4bb0f83a-obtain-pid-sdjwt.outputs | optional }}
+                    onboard-reference-wallet: ${{ engagement-haip-vp-4bb0f83a-onboard-reference-wallet.outputs | optional }}
+                    pid_sdjwt: ${{ engagement-haip-vp-4bb0f83a-fetch-capture-session.outputs.body.observed.wallet_response.value.vp_token | optional }}
+                    pid_sdjwt_presentations: ${{ engagement-haip-vp-4bb0f83a-fetch-capture-session.outputs.body.observed.wallet_response.value.vp_token | optional }}
+                    visual_evidence: ${{ engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp.outputs.flow_output.maestro_screenshot_urls | optional }}
+            pipeline.wallet.engagement.haip-vp:
+                output:
+                    create-capture-session: ${{ engagement-haip-vp-4bb0f83a-create-capture-session.outputs | optional }}
+                    create-pid-sdjwt-offer: ${{ engagement-haip-vp-4bb0f83a-create-pid-sdjwt-offer.outputs | optional }}
+                    fetch-capture-session: ${{ engagement-haip-vp-4bb0f83a-fetch-capture-session.outputs | optional }}
+                    invoke-wallet-with-haip-vp: ${{ engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp.outputs | optional }}
+                    obtain-pid-sdjwt: ${{ engagement-haip-vp-4bb0f83a-obtain-pid-sdjwt.outputs | optional }}
+                    onboard-reference-wallet: ${{ engagement-haip-vp-4bb0f83a-onboard-reference-wallet.outputs | optional }}
+                    visual_evidence: ${{ engagement-haip-vp-4bb0f83a-invoke-wallet-with-haip-vp.outputs.flow_output.maestro_screenshot_urls | optional }}
+                    wallet_engagement: ${{ engagement-haip-vp-4bb0f83a-fetch-capture-session.outputs.body | optional }}
+            pipeline.wallet.protocol.request-object-by-value:
+                output:
+                    create-presentation: ${{ request-object-by-value-f1c94061-create-presentation.outputs | optional }}
+                    dcql_exchange: ${{ request-object-by-value-f1c94061-get-presentation-result.outputs.body | optional }}
+                    get-presentation-result: ${{ request-object-by-value-f1c94061-get-presentation-result.outputs | optional }}
+                    request_object: ${{ request-object-by-value-f1c94061-create-presentation.outputs.body.request | optional }}
+                    submit-request-object-by-value: ${{ request-object-by-value-f1c94061-submit-request-object-by-value.outputs | optional }}
+                    visual_evidence: ${{ request-object-by-value-f1c94061-submit-request-object-by-value.outputs.flow_output.maestro_screenshot_urls | optional }}
+                    wallet_response: ${{ request-object-by-value-f1c94061-get-presentation-result.outputs.body | optional }}
+        suite: wallet_solution/relying_party
+        test_ids:
+            - WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_AddressData_Emailaddress_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Emailaddress_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Emailaddress_PID_ISO-mdoc_003
+            - WS_RP_DM_AddressData_Mobilephonenumber_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Mobilephonenumber_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Mobilephonenumber_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_AddressData_Mobilephonenumber_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Mobilephonenumber_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Mobilephonenumber_PID_ISO-mdoc_003
+            - WS_RP_DM_AddressData_Residentaddress_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residentaddress_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residentaddress_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residentaddress_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Residentcity_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residentcity_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residentcity_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residentcity_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Residentcountry_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residentcountry_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residentcountry_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_AddressData_Residentcountry_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residentcountry_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Residentcountry_PID_ISO-mdoc_003
+            - WS_RP_DM_AddressData_Residenthousenumber_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residenthousenumber_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residenthousenumber_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residenthousenumber_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Residentpostalcode_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residentpostalcode_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residentpostalcode_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residentpostalcode_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Residentstate_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residentstate_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residentstate_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residentstate_PID_ISO-mdoc_002
+            - WS_RP_DM_AddressData_Residentstreet_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_AddressData_Residentstreet_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_AddressData_Residentstreet_PID_ISO-mdoc_001
+            - WS_RP_DM_AddressData_Residentstreet_PID_ISO-mdoc_002
+            - WS_RP_DM_CredentialMetadata_CredentialStructure_008
+            - WS_RP_DM_Credentialmetadata_Documentnumber_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Documentnumber_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Documentnumber_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Documentnumber_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Domestic_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Domestic_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Domestic_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Domestic_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_IETF-sd-jwt-vc_004
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_ISO-mdoc_003
+            - WS_RP_DM_Credentialmetadata_Expirydate_PID_ISO-mdoc_004
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_IETF-sd-jwt-vc_004
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_ISO-mdoc_003
+            - WS_RP_DM_Credentialmetadata_Issuancedate_PID_ISO-mdoc_004
+            - WS_RP_DM_Credentialmetadata_Issuingauthority_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Issuingauthority_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Issuingauthority_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Issuingauthority_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Issuingcountry_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Issuingcountry_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Issuingcountry_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_Credentialmetadata_Issuingcountry_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Issuingcountry_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Issuingcountry_PID_ISO-mdoc_003
+            - WS_RP_DM_Credentialmetadata_Issuingjurisdiction_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_Credentialmetadata_Issuingjurisdiction_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_Credentialmetadata_Issuingjurisdiction_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_Credentialmetadata_Issuingjurisdiction_PID_ISO-mdoc_001
+            - WS_RP_DM_Credentialmetadata_Issuingjurisdiction_PID_ISO-mdoc_002
+            - WS_RP_DM_Credentialmetadata_Issuingjurisdiction_PID_ISO-mdoc_003
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_IETF-sd-jwt-vc_004
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_ISO-mdoc_003
+            - WS_RP_DM_IdentifyingData_Birthdate_PID_ISO-mdoc_004
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_003
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_004
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_005
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_006
+            - WS_RP_DM_IdentifyingData_Birthplace_PID_ISO-mdoc_007
+            - WS_RP_DM_IdentifyingData_Familyname_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Familyname_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Familyname_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Familyname_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Familynamebirth_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Familynamebirth_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Familynamebirth_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Familynamebirth_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Givenname_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Givenname_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Givenname_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Givenname_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Givennamebirth_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Givennamebirth_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Givennamebirth_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Givennamebirth_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Nationality_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Nationality_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Nationality_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_IdentifyingData_Nationality_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Nationality_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Nationality_PID_ISO-mdoc_003
+            - WS_RP_DM_IdentifyingData_Nationality_PID_ISO-mdoc_004
+            - WS_RP_DM_IdentifyingData_Personaladministrativenumber_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Personaladministrativenumber_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Personaladministrativenumber_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Personaladministrativenumber_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Portrait_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Portrait_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Portrait_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_IdentifyingData_Portrait_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Portrait_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Portrait_PID_ISO-mdoc_003
+            - WS_RP_DM_IdentifyingData_Sex_PID_IETF-sd-jwt-vc_001
+            - WS_RP_DM_IdentifyingData_Sex_PID_IETF-sd-jwt-vc_002
+            - WS_RP_DM_IdentifyingData_Sex_PID_IETF-sd-jwt-vc_003
+            - WS_RP_DM_IdentifyingData_Sex_PID_ISO-mdoc_001
+            - WS_RP_DM_IdentifyingData_Sex_PID_ISO-mdoc_002
+            - WS_RP_DM_IdentifyingData_Sex_PID_ISO-mdoc_003
+            - WS_RP_IA_Engagement__001
+            - WS_RP_IA_MainInteraction__006
+            - WS_RP_IA_MainInteraction__010
+            - WS_RP_IA_MainInteraction__015
+            - WS_RP_IA_MainInteraction__016
+            - WS_RP_IA_MainInteraction__017
+            - WS_RP_IA_MainInteraction__018
+            - WS_RP_IA_MainInteraction__019
+            - WS_RP_IA_MainInteraction__020
+            - WS_RP_IA_MainInteraction__021
+            - WS_RP_IA_MainInteraction__022
+            - WS_RP_IA_MainInteraction__023
+            - WS_RP_IA_MainInteraction__024
+            - WS_RP_IA_MainInteraction__025
+            - WS_RP_IA_MainInteraction__026
+            - WS_RP_IA_MainInteraction__027
+            - WS_RP_IA_MainInteraction__028
+            - WS_RP_IA_MainInteraction__029
+            - WS_RP_IA_MainInteraction__030
+            - WS_RP_IA_MainInteraction__031
+            - WS_RP_IA_MainInteraction__032
+            - WS_RP_IA_MainInteraction__033
+            - WS_RP_IA_MainInteraction__034
+            - WS_RP_IA_MainInteraction__035
+            - WS_RP_IA_MainInteraction__036
+            - WS_RP_IA_MainInteraction__037
+            - WS_RP_IA_MainInteraction__038
+            - WS_RP_IA_MainInteraction__039
+            - WS_RP_IA_MainInteraction__040
+            - WS_RP_IA_MainInteraction__041
+            - WS_RP_IA_MainInteraction__042
+            - WS_RP_IA_MainInteraction__043
+            - WS_RP_IA_MainInteraction__046
+            - WS_RP_IA_MainInteraction__049
+            - WS_RP_IA_MainInteraction__052
+            - WS_RP_IA_MainInteraction__053
+            - WS_RP_IA_MainInteraction__054
+            - WS_RP_IA_MainInteraction__055
+            - WS_RP_IA_MainInteraction__056
+            - WS_RP_IA_MainInteraction__057
+            - WS_RP_IA_MainInteraction__060
+            - WS_RP_IA_MainInteraction__061
+            - WS_RP_IA_MainInteraction__064
+            - WS_RP_IA_MainInteraction__065
+            - WS_RP_IA_MainInteraction__066
+            - WS_RP_IA_MainInteraction__067
+            - WS_RP_IA_Metadata__009
+            - WS_RP_IA_Metadata__010
+            - WS_RP_IA_Metadata__011
+            - WS_RP_IA_Metadata__012
+            - WS_RP_IA_Metadata__013
+            - WS_RP_IA_Metadata__014
+            - WS_RP_IA_Metadata__015
+            - WS_RP_IA_Metadata__016
+            - WS_RP_IA_Metadata__017
+            - WS_RP_MS_CredentialFormats__029
+            - WS_RP_MS_CredentialFormats__030
+            - WS_RP_MS_CredentialFormats__031
+            - WS_RP_MS_CredentialFormats__032
+            - WS_RP_MS_CredentialFormats__033
+            - WS_RP_MS_CredentialFormats__034
+            - WS_RP_MS_CredentialFormats__035
+            - WS_RP_MS_CredentialFormats__036
+            - WS_RP_MS_CredentialFormats__037
+            - WS_RP_MS_CredentialFormats__038
+            - WS_RP_MS_CredentialFormats__039
+            - WS_RP_MS_CredentialFormats__040
+            - WS_RP_MS_CredentialFormats__041
+            - WS_RP_MS_CredentialFormats__044
+            - WS_RP_MS_CredentialFormats__045
+            - WS_RP_MS_CredentialFormats__046
+            - WS_RP_MS_CredentialFormats__048
+            - WS_RP_MS_Metadata__081
+            - WS_RP_MS_Metadata__082
+            - WS_RP_MS_Metadata__083
+            - WS_RP_MS_Metadata__084
+            - WS_RP_MS_Metadata__085
+            - WS_RP_MS_Metadata__086
+            - WS_RP_MS_Metadata__087
+            - WS_RP_MS_Metadata__088
+            - WS_RP_MS_Metadata__089
+            - WS_RP_MS_Metadata__090
+            - WS_RP_MS_Metadata__091
+            - WS_RP_MS_Metadata__092
+            - WS_RP_MS_Metadata__093
+            - WS_RP_MS_Metadata__094
+            - WS_RP_MS_Metadata__095
+            - WS_RP_MS_Metadata__096
+            - WS_RP_MS_Metadata__097
+            - WS_RP_MS_Metadata__098
+            - WS_RP_MS_Metadata__099
+            - WS_RP_MS_Metadata__100
+            - WS_RP_MS_Metadata__101
+            - WS_RP_MS_Metadata__102
+            - WS_RP_MS_Metadata__103
+            - WS_RP_MS_Metadata__104
+            - WS_RP_MS_Metadata__105
+            - WS_RP_MS_Metadata__106
+            - WS_RP_MS_Metadata__107
+            - WS_RP_MS_Metadata__108
+            - WS_RP_MS_Metadata__109
+            - WS_RP_MS_Metadata__110
+            - WS_RP_MS_Metadata__111
+            - WS_RP_MS_Metadata__112
+            - WS_RP_MS_Metadata__113
+            - WS_RP_MS_Metadata__114
+            - WS_RP_MS_Metadata__115
+            - WS_RP_MS_Metadata__116
+            - WS_RP_MS_Metadata__117
+            - WS_RP_MS_Metadata__118
+            - WS_RP_MS_Metadata__119
+            - WS_RP_MS_Metadata__120
+            - WS_RP_MS_Metadata__121
+            - WS_RP_MS_Metadata__122
+            - WS_RP_MS_Metadata__123
+            - WS_RP_MS_Metadata__124
+            - WS_RP_MS_Metadata__125
+            - WS_RP_MS_Metadata__126
+            - WS_RP_MS_Metadata__127
+            - WS_RP_MS_Metadata__128
+            - WS_RP_MS_Metadata__129
+            - WS_RP_MS_Metadata__130
+            - WS_RP_MS_Metadata__131
+            - WS_RP_MS_Metadata__132
+            - WS_RP_MS_Metadata__133
+            - WS_RP_MS_Metadata__134
+            - WS_RP_MS_Metadata__135
+            - WS_RP_MS_Metadata__136
+            - WS_RP_MS_Metadata__137
+            - WS_RP_MS_Metadata__138
+            - WS_RP_MS_Metadata__139
+            - WS_RP_MS_Metadata__140
+            - WS_RP_MS_Metadata__141
+            - WS_RP_MS_ProtocolMessages__002
+            - WS_RP_MS_ProtocolMessages__003
+            - WS_RP_MS_ProtocolMessages__004
+            - WS_RP_MS_ProtocolMessages__006
+            - WS_RP_MS_ProtocolMessages__007
+            - WS_RP_MS_ProtocolMessages__008
+            - WS_RP_MS_ProtocolMessages__009
+            - WS_RP_MS_ProtocolMessages__010
+            - WS_RP_MS_ProtocolMessages__011
+            - WS_RP_MS_ProtocolMessages__012
+            - WS_RP_MS_ProtocolMessages__014
+            - WS_RP_MS_ProtocolMessages__015
+            - WS_RP_MS_ProtocolMessages__016
+            - WS_RP_MS_ProtocolMessages__017
+            - WS_RP_MS_ProtocolMessages__018
+            - WS_RP_MS_ProtocolMessages__019
+            - WS_RP_MS_ProtocolMessages__020
+            - WS_RP_MS_ProtocolMessages__021
+            - WS_RP_MS_ProtocolMessages__024
+            - WS_RP_MS_ProtocolMessages__025
+            - WS_RP_MS_ProtocolMessages__026
+            - WS_RP_MS_ProtocolMessages__027
+            - WS_RP_MS_ProtocolMessages__028
+            - WS_RP_MS_ProtocolMessages__029
+            - WS_RP_MS_ProtocolMessages__030
+            - WS_RP_MS_ProtocolMessages__032
+            - WS_RP_MS_ProtocolMessages__033
+            - WS_RP_MS_ProtocolMessages__034
+            - WS_RP_MS_ProtocolMessages__035
+            - WS_RP_MS_ProtocolMessages__036
+            - WS_RP_MS_ProtocolMessages__037
+            - WS_RP_MS_ProtocolMessages__038
+            - WS_RP_MS_ProtocolMessages__039
+            - WS_RP_MS_ProtocolMessages__040
+            - WS_RP_MS_ProtocolMessages__041
+            - WS_RP_MS_ProtocolMessages__042
+            - WS_RP_MS_ProtocolMessages__043
+            - WS_RP_MS_ProtocolMessages__044
+            - WS_RP_MS_ProtocolMessages__045
+            - WS_RP_MS_ProtocolMessages__046
+            - WS_RP_MS_ProtocolMessages__047
+            - WS_RP_MS_ProtocolMessages__048
+            - WS_RP_MS_ProtocolMessages__049
+            - WS_RP_MS_ProtocolMessages__050
+            - WS_RP_MS_ProtocolMessages__051
+            - WS_RP_MS_ProtocolMessages__052
+            - WS_RP_MS_ProtocolMessages__053
+            - WS_RP_MS_ProtocolMessages__054
+            - WS_RP_MS_ProtocolMessages__055
+            - WS_RP_MS_ProtocolMessages__056
+            - WS_RP_MS_ProtocolMessages__057
+            - WS_RP_MS_ProtocolMessages__058
+            - WS_RP_MS_ProtocolMessages__059
+            - WS_RP_MS_ProtocolMessages__060
+            - WS_RP_MS_ProtocolMessages__061
+            - WS_RP_MS_ProtocolMessages__062
+            - WS_RP_MS_ProtocolMessages__063
+            - WS_RP_MS_ProtocolMessages__065
+            - WS_RP_MS_ProtocolMessages__066
+            - WS_RP_MS_ProtocolMessages__068
+            - WS_RP_MS_ProtocolMessages__069
+            - WS_RP_MS_ProtocolMessages__070
+            - WS_RP_MS_ProtocolMessages__072
+            - WS_RP_MS_ProtocolMessages__074
+            - WS_RP_MS_ProtocolMessages__075
+            - WS_RP_MS_ProtocolMessages__076
+            - WS_RP_MS_ProtocolMessages__077
+            - WS_RP_MS_ProtocolMessages__078
+            - WS_RP_MS_ProtocolMessages__079
+            - WS_RP_MS_ProtocolMessages__095
+            - WS_RP_MS_ProtocolMessages__105
+            - WS_RP_MS_ProtocolMessages__119
+            - WS_RP_SH_Cryptography_CryptographicHash_001
+            - WS_RP_SH_Cryptography_CryptographicHash_002
+            - WS_RP_SH_Cryptography_CryptographicHash_006
+            - WS_RP_SH_Cryptography_CryptographicHash_007
+            - WS_RP_SH_Cryptography_CryptographicHash_008
+            - WS_RP_SH_Cryptography_CryptographicHash_010
+            - WS_RP_SH_Cryptography_Encryption_002
+            - WS_RP_SM_DeviceBinding__002
+            - WS_RP_SM_DeviceBinding__003
+            - WS_RP_SM_DeviceBinding__004
+            - WS_RP_SM_DeviceBinding__005
+            - WS_RP_SM_DeviceBinding__006
+            - WS_RP_SM_DeviceBinding__007
+            - WS_RP_SM_DeviceBinding__010
+            - WS_RP_SM_DeviceBinding__011
+            - WS_RP_SM_DeviceBinding__012
+            - WS_RP_SM_IssuerIntegrity__013
+            - WS_RP_SM_RpIntegrity_CryptographicSignature_002
+            - WS_RP_SM_RpIntegrity_CryptographicSignature_003
+            - WS_RP_SM_RpIntegrity_CryptographicSignature_004
+            - WS_RP_SM_RpIntegrity__001
+            - WS_RP_SM_RpIntegrity__002
+            - WS_RP_SM_RpIntegrity__003
+            - WS_RP_SM_RpIntegrity__004
+            - WS_RP_SM_RpIntegrity__005
+            - WS_RP_SM_RpIntegrity__006
+            - WS_RP_SM_RpIntegrity__007
+            - WS_RP_SM_RpIntegrity__008
+            - WS_RP_SM_RpIntegrity__009
+            - WS_RP_SM_RpIntegrity__010
+            - WS_RP_SM_RpIntegrity__011
+            - WS_RP_SM_RpIntegrity__012
+            - WS_RP_SM_RpIntegrity__013
+            - WS_RP_SM_RpIntegrity__014
+            - WS_RP_SM_RpIntegrity__015
+            - WS_RP_SM_RpIntegrity__016
+            - WS_RP_SM_RpIntegrity__017
+            - WS_RP_SM_RpIntegrity__018
+            - WS_RP_SM_RpIntegrity__019
+            - WS_RP_SM_RpIntegrity__020
+            - WS_RP_SM_RpIntegrity__021
+            - WS_RP_SM_RpIntegrity__022
+            - WS_RP_SM_RpIntegrity__023
+            - WS_RP_SM_RpIntegrity__024
+            - WS_RP_SM_RpIntegrity__025
+            - WS_RP_SM_RpIntegrity__026
+            - WS_RP_SM_RpIntegrity__027
+            - WS_RP_SM_RpIntegrity__028
+            - WS_RP_SM_RpIntegrity__029
+            - WS_RP_SM_RpIntegrity__030
+            - WS_RP_SM_RpIntegrity__031
+            - WS_RP_SM_RpIntegrity__032
+            - WS_RP_SM_RpIntegrity__033
+            - WS_RP_SM_RpIntegrity__034
+            - WS_RP_SM_SessionEncryption__001
+            - WS_RP_SM_SessionEncryption__002
+            - WS_RP_SM_SessionEncryption__003
+            - WS_RP_SM_SessionEncryption__005
+            - WS_RP_SM_SessionEncryption__006
+            - WS_RP_SM_SessionEncryption__007
+            - WS_RP_SM_SessionEncryption__008
+            - WS_RP_SM_SessionEncryption__009
+            - WS_RP_SM_SessionEncryption__010
+            - WS_RP_SM_SessionEncryption__011
+            - WS_RP_SM_SessionEncryption__012
+            - WS_RP_SM_TrustMechanisms__002
+            - WS_RP_SM_TrustMechanisms__003
+            - WS_RP_SM_TrustMechanisms__004
+            - WS_RP_SM_TrustMechanisms__005
+            - WS_RP_SM_TrustMechanisms__006
+            - WS_RP_SM_TrustMechanisms__007
+            - WS_RP_SM_TrustMechanisms__008
+            - WS_RP_SM_TrustMechanisms__009
+            - WS_RP_SM_TrustMechanisms__010
+            - WS_RP_SM_TrustMechanisms__011
+            - WS_RP_SM_TrustMechanisms__012
+            - WS_RP_SM_TrustMechanisms__013
+            - WS_RP_SM_TrustMechanisms__015
+            - WS_RP_SM_TrustMechanisms__021

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-credential-formats.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-credential-formats.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: credential-formats\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-cryptography.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-cryptography.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: cryptography\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-device-binding.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-device-binding.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: device-binding\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-interaction-metadata.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-interaction-metadata.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: interaction-metadata\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-main-interaction.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-main-interaction.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: main-interaction\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-metadata.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-metadata.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: metadata\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-protocol-messages.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-protocol-messages.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: protocol-messages\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-rp-integrity.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-rp-integrity.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: rp-integrity\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-session-encryption.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-session-encryption.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: session-encryption\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-trust-mechanisms.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-dcql-trust-mechanisms.yaml
@@ -41,26 +41,10 @@ steps:
 - id: exercise-wallet
   use: mobile-automation
   with:
+    action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-exercise-wallet-generic
     version_id: installed_from_external_source
     parameters:
-      DEEPLINK: ${{ create-capture-session.outputs.body.deeplink }}
-    action_code: "appId: eu.europa.ec.euidi\n---\n- launchApp:\n    stopApp: true\n    clearState: false\n    permissions:\n\
-      \      camera: allow\n      notifications: allow\n      all: unset\n- extendedWaitUntil:\n    visible: \"Welcome back|Home|Documents|Add\
-      \ document|Welcome, .*\"\n    timeout: 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n\
-      \      - tapOn:\n          point: \"11%,40%\"\n      - inputText: \"123456\"\n      - hideKeyboard\n      - tapOn:\n\
-      \          point: \"50%,10%\"\n- extendedWaitUntil:\n    visible: \"Home|Documents|Add document|Welcome, .*\"\n    timeout:\
-      \ 30000\n- openLink:\n    link: \"${DEEPLINK}\"\n    autoVerify: false\n    browser: false\n- runFlow:\n    when:\n\
-      \      visible: \"EUDI Wallet\"\n    commands:\n      - tapOn:\n          text: \"EUDI Wallet\"\n          optional:\
-      \ true\n- runFlow:\n    when:\n      visible: \"Just once\"\n    commands:\n      - tapOn:\n          text: \"Just once\"\
-      \n          optional: true\n- runFlow:\n    when:\n      visible: \"Always\"\n    commands:\n      - tapOn:\n      \
-      \    text: \"Always\"\n          optional: true\n- extendedWaitUntil:\n    visible: \"Welcome back|Error|invalid request|Something\
-      \ went wrong|DATA SHARING REQUEST\"\n    timeout: 100000\n- runFlow:\n    when:\n      visible: \"DATA SHARING REQUEST\"\
-      \n    commands:\n      - tapOn: \"Share\"\n      - extendedWaitUntil:\n          visible: \"PIN\"\n          timeout:\
-      \ 30000\n      - tapOn:\n          point: \"11%,39%\"\n      - inputText: \"123456\"\n      - tapOn:\n          point:\
-      \ \"50%,10%\"\n      - extendedWaitUntil:\n          visible: \".*successfully shared.*|Welcome back\"\n          timeout:\
-      \ 30000\n- runFlow:\n    when:\n      visible: \"Welcome back\"\n    commands:\n      - tapOn:\n          point: \"\
-      11%,40%\"\n      - inputText: \"123456\"\n- extendedWaitUntil:\n    visible: \"Error|invalid request|Something went\
-      \ wrong|Home|Documents\"\n    timeout: 30000\n- takeScreenshot: trust-mechanisms\n- back"
+      deeplink: ${{ create-capture-session.outputs.body.deeplink }}
 - id: fetch-capture-session
   use: http-request
   with:

--- a/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-request-object-by-value.yaml
+++ b/config_templates/fcaf/wallet_solution/relying_party/scenarios/fcaf-wallet-solution-relying-party-request-object-by-value.yaml
@@ -38,52 +38,11 @@ steps:
   - id: submit-request-object-by-value
     use: mobile-automation
     with:
+      action_id: forkbomb-bv-andrea/eudiw-beta-wallet/fcaf-submit-request-object-by-value
       version_id: installed_from_external_source
       parameters:
         CLIENT_ID: ${{ create-presentation.outputs.body.client_id }}
         REQUEST_OBJECT: ${{ create-presentation.outputs.body.request }}
-      action_code: |
-        appId: eu.europa.ec.euidi
-        ---
-        - stopApp
-        - evalScript: ${output.authorizationRequest = 'haip-vp://?client_id=' + encodeURIComponent(env.CLIENT_ID) + '&request=' + encodeURIComponent(env.REQUEST_OBJECT)}
-        - openLink:
-            link: ${output.authorizationRequest}
-            autoVerify: false
-            browser: false
-        - waitForAnimationToEnd:
-            timeout: 5000
-        - tapOn:
-            text: "EUDI Wallet"
-            optional: true
-        - tapOn:
-            text: "Just once"
-            optional: true
-        - extendedWaitUntil:
-            visible: "Welcome back|Share|Cancel|Close"
-            timeout: 100000
-        - runFlow:
-            when:
-              visible: "Welcome back"
-            commands:
-              - tapOn:
-                  point: "11%,40%"
-              - inputText: "123456"
-        - extendedWaitUntil:
-            visible: "Share"
-            timeout: 30000
-        - tapOn:
-            text: "Share"
-            enabled: true
-        - extendedWaitUntil:
-            visible: "verify your identity|PIN"
-            timeout: 30000
-        - inputText: "123456"
-        - extendedWaitUntil:
-            visible: "Close"
-            timeout: 30000
-        - assertVisible: "Close"
-        - takeScreenshot: fcaf-request-object-by-value-accepted
 
   - id: get-presentation-result
     use: http-request

--- a/deployment/dynamicconfig/development-sql.yaml
+++ b/deployment/dynamicconfig/development-sql.yaml
@@ -7,3 +7,10 @@ limit.maxIDLength:
 system.forceSearchAttributesCacheRefreshOnRead:
   - value: true # Dev setup only. Please don't turn this on in production.
     constraints: {}
+# FCAF aggregate validation reports exceed the default 2MB per-event blob limit.
+limit.blobSize.error:
+  - value: 104857600
+    constraints: {}
+limit.blobSize.warn:
+  - value: 104857600
+    constraints: {}

--- a/pb_migrations/1788210267_updated_fcaf_report_pdf_max_size.js
+++ b/pb_migrations/1788210267_updated_fcaf_report_pdf_max_size.js
@@ -1,0 +1,52 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate(
+    (app) => {
+        const collection = app.findCollectionByNameOrId("pbc_2980015441");
+
+        // update field: raise the FCAF report PDF size limit
+        // (maxSize 0 falls back to the 5 MiB PocketBase default)
+        collection.fields.addAt(
+            15,
+            new Field({
+                hidden: false,
+                id: "file_fcaf_report_pdf",
+                maxSize: 52428800,
+                maxSelect: 1,
+                mimeTypes: ["application/pdf"],
+                name: "fcaf_report_pdf",
+                presentable: false,
+                protected: false,
+                required: false,
+                system: false,
+                thumbs: [],
+                type: "file",
+            }),
+        );
+
+        return app.save(collection);
+    },
+    (app) => {
+        const collection = app.findCollectionByNameOrId("pbc_2980015441");
+
+        // update field: restore the default FCAF report PDF size limit
+        collection.fields.addAt(
+            15,
+            new Field({
+                hidden: false,
+                id: "file_fcaf_report_pdf",
+                maxSize: 0,
+                maxSelect: 1,
+                mimeTypes: ["application/pdf"],
+                name: "fcaf_report_pdf",
+                presentable: false,
+                protected: false,
+                required: false,
+                system: false,
+                thumbs: [],
+                type: "file",
+            }),
+        );
+
+        return app.save(collection);
+    },
+);

--- a/pkg/fcaf/MEMORY.md
+++ b/pkg/fcaf/MEMORY.md
@@ -41,6 +41,53 @@ On 27/08/2026, maintainer removed legacy FCAF orchestration. `/api/fcaf/run`, as
 
 Maintain 112 evidence-producing source definitions under `config_templates/fcaf/wallet_solution/relying_party/scenarios/`. `make fcaf-generate` combines them into one deployable pipeline, prefixes scenario step IDs, continues after scenario failures, merges 115 exact evidence sources, and runs one final `fcaf-validation` over all 559 tests. `pipelines/` contains only this generated complete-validation pipeline, so sync/run creates one top-level FCAF execution.
 
+## Happy flow aggregate pipeline
+
+On 31/08/2026 `cmd/fcaf-pipeline-gen` gained a third generated pipeline,
+`fcaf-wallet-solution-relying-party-happy-flow-validation.yaml`: the
+shared-evidence positive batch of the FCAF catalog, deliberately NOT the
+complete assessment. `happyFlowScenarioNames` selects the 14 scenarios that
+own every positive test batch (>= 5 positive tests each): 423 test IDs, 17
+evidence sources, 53 steps, 21 mobile-automation actions. Excluded: all
+negative tests and the fragmented one-test-per-interaction DCQL tail that
+only the complete validation aggregate covers. Reuses only existing wallet
+actions (`onboarding-1`, `getcredential-generic-credential-without-authentication`,
+`fcaf-engagement-haip-vp`); no new Maestro actions are needed. The
+maintainer rejected both a positives-only aggregate of all 75 positive
+scenarios (500 tests, ~86 wallet actions, "full assessment minus negatives")
+and a strict single-presentation flow (72 tests, below the 200+ check
+expectation). Deployment to the fcaf-1 org on credimi.io: apply the CLI org
+rewrite (`forkbomb-bv-andrea/` -> `fcaf-1/`), drop `runtime.global_runner_id`,
+and upload the record; the webapp queue flow injects the UI-selected runner
+as `global_runner_id` at queue time. `installed_from_external_source` is a
+platform sentinel (use the wallet pre-installed on the runner), not a
+wallet_versions lookup, and needs no org rewrite.
+
+## Happy flow fcaf-1 deployment incident
+
+The first credimi.io/fcaf-1 run of the happy flow pipeline (31/08/2026,
+17:21) failed during workflow setup: `markExternalInstallSteps` resolved
+`workflowengine.AsString(nil)` — the literal string `"<nil>"` — as an
+action identifier for the eleven `installed_from_external_source` steps
+that carry inline `action_code` and no `action_id`, so the canonify
+validate endpoint returned CRE310 `invalid path "<nil>"`. Two-part remedy:
+
+1. Repo fix (uncommitted in the fcaf-happy-flow worktree):
+   `markExternalInstallSteps` now skips sentinel steps without a string
+   `action_id`; regression test
+   `TestMarkExternalInstallStepsSkipsInlineActionCodeSteps` fails on the
+   unfixed code. Deploy with the next server release.
+2. Instance-side pipeline shim (record `7j70w1pf7pqpl23`, patched 17:27):
+   those eleven steps now declare
+   `action_id: fcaf-1/eudiw-beta-wallet/fcaf-engagement-haip-vp`
+   (category `verify-credential`, never `install-app`). Execution is
+   unchanged because the mobile-automation child workflow runs
+   `payload.ActionCode`, not the stored action; the shim only feeds the
+   category lookup. Replace the shim with the repo fix once deployed.
+
+The complete-validation pipeline hits the same setup bug on any current
+server build; it is not fcaf-1-specific.
+
 Every test has exactly one scenario owner. Do not restore sole-output fallback: one wallet interaction must never stand in for incompatible scenarios. A complete run may still contain many sequential wallet interactions. Mock-verifier-blocked tests must report blocked/failed from missing real evidence, never synthetic conformance passes.
 
 ## Case 087
@@ -463,3 +510,22 @@ Active worktrees prepared from `54373c67`:
 - 093: `/tmp/credimi-fcaf-093`, branch `test/fcaf-093-authority-value-items`
 
 Each worktree contains an untracked `AGENT_TASK.md`. Agents own only test-specific artifacts. Shared integration files remain owned by the main worktree and must be updated after the four branches are reviewed/cherry-picked. Code work can run concurrently; emulator/Maestro runs cannot because all agents share `emulator-5580`.
+
+## Wallet step editor compatibility (2026-09-01)
+
+The pipeline editor could not display inline `action_code` mobile-automation
+steps ("Invalid pipeline step data"): `walletActionStepConfig.deserialize`
+requires `action_id`. The 11 happy-flow scenarios that used inline code now
+reference two stored wallet actions synced from
+`config_templates/fcaf/imports/forkbomb-bv-andrea/wallet/`:
+`fcaf-exercise-wallet-generic` (generic capture-session exercise, `deeplink`
+parameter, fixed `exercise-wallet` screenshot label) and
+`fcaf-submit-request-object-by-value` (`CLIENT_ID`/`REQUEST_OBJECT`
+parameters). Both keep `version_id: installed_from_external_source`, which the
+editor resolves as the external version. The editor now also round-trips
+arbitrary step `parameters` on edit instead of only `deeplink`.
+
+The ~90 fragmented one-test DCQL scenarios in the complete-validation
+aggregate still use inline `action_code` and remain flagged in the editor;
+converting them needs their distinct mock-deeplink flow templates extracted
+first (see scenario sources under `scenarios/fcaf-wallet-solution-relying-party-dcql-*`).

--- a/pkg/fcaf/engine/report.go
+++ b/pkg/fcaf/engine/report.go
@@ -77,11 +77,22 @@ type FailureReason struct {
 }
 
 type ExecutedTest struct {
-	TestID     string          `json:"test_id"`
-	Title      string          `json:"title,omitempty"`
-	Status     string          `json:"status"`
-	Assertions []ExecutedCheck `json:"assertions,omitempty"`
-	Outcome    TestOutcome     `json:"outcome"`
+	TestID     string             `json:"test_id"`
+	Title      string             `json:"title,omitempty"`
+	Status     string             `json:"status"`
+	Assertions []ExecutedCheck    `json:"assertions,omitempty"`
+	Evidence   []ExecutedEvidence `json:"evidence,omitempty"`
+	Outcome    TestOutcome        `json:"outcome"`
+}
+
+// ExecutedEvidence records which evidence a test consumed. The flat report
+// evidence map keeps only one record per name, so per-test consumers such as
+// the PDF and the webapp sheet must use this list to attach the right
+// scenario's artifacts to each test.
+type ExecutedEvidence struct {
+	Name       string   `json:"name"`
+	SourceNode string   `json:"source_node,omitempty"`
+	Visual     []string `json:"visual,omitempty"`
 }
 
 type ExecutedCheck struct {
@@ -174,6 +185,17 @@ func (r *Report) PopulateExecutedTests() {
 				Status:       normalizeExecutionStatus(assertion.Status),
 				Message:      assertion.Message,
 				EvidenceKeys: append([]string(nil), assertion.EvidenceKeys...),
+			})
+		}
+		for _, item := range test.Evidence {
+			visual := ImageReferenceURLs(item.Value)
+			if len(visual) == 0 && item.Name == "" {
+				continue
+			}
+			executed.Evidence = append(executed.Evidence, ExecutedEvidence{
+				Name:       item.Name,
+				SourceNode: item.SourceNode,
+				Visual:     visual,
 			})
 		}
 		r.ExecutedTests = append(r.ExecutedTests, executed)

--- a/pkg/fcaf/engine/report_test.go
+++ b/pkg/fcaf/engine/report_test.go
@@ -84,3 +84,40 @@ func TestPopulateExecutedTestsFailsWhenAssertionFails(t *testing.T) {
 	require.Equal(t, "failed", report.ExecutedTests[0].Status)
 	require.Equal(t, `claim "email" is missing`, report.ExecutedTests[0].Outcome.Reason)
 }
+
+func TestPopulateExecutedTestsCarriesPerTestVisualEvidence(t *testing.T) {
+	first := Report{Tests: []TestResult{{
+		ID:     "cryptography-test",
+		Status: validators.StatusPass,
+		Evidence: []EvidenceResult{{
+			Name:       "visual_evidence",
+			SourceNode: "pipeline.dcql.cryptography",
+			Value:      []any{"https://app.test/a/cryptography.png"},
+		}},
+	}}}
+	second := Report{Tests: []TestResult{{
+		ID:     "trust-test",
+		Status: validators.StatusPass,
+		Evidence: []EvidenceResult{{
+			Name:       "visual_evidence",
+			SourceNode: "pipeline.dcql.trust-mechanisms",
+			Value:      []any{"https://app.test/a/trust.png"},
+		}},
+	}}}
+
+	first.PopulateDerivedViews()
+	second.PopulateDerivedViews()
+
+	require.Len(t, first.ExecutedTests[0].Evidence, 1)
+	require.Equal(t, "pipeline.dcql.cryptography", first.ExecutedTests[0].Evidence[0].SourceNode)
+	require.Equal(
+		t,
+		[]string{"https://app.test/a/cryptography.png"},
+		first.ExecutedTests[0].Evidence[0].Visual,
+	)
+	require.Equal(
+		t,
+		[]string{"https://app.test/a/trust.png"},
+		second.ExecutedTests[0].Evidence[0].Visual,
+	)
+}

--- a/pkg/fcaf/engine/visual.go
+++ b/pkg/fcaf/engine/visual.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package engine
+
+import (
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+)
+
+// ImageReferenceURLs collects every image reference URL inside an evidence
+// value, depth-first, deduplicated and in stable order.
+func ImageReferenceURLs(value any) []string {
+	seen := map[string]struct{}{}
+	collectImageReferences(value, seen)
+	urls := make([]string, 0, len(seen))
+	for reference := range seen {
+		urls = append(urls, reference)
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+func collectImageReferences(value any, seen map[string]struct{}) {
+	switch typed := value.(type) {
+	case string:
+		if isImageReference(typed) {
+			seen[typed] = struct{}{}
+		}
+	case []any:
+		for _, child := range typed {
+			collectImageReferences(child, seen)
+		}
+	case []string:
+		for _, child := range typed {
+			collectImageReferences(child, seen)
+		}
+	case map[string]any:
+		for _, child := range typed {
+			collectImageReferences(child, seen)
+		}
+	}
+}
+
+func isImageReference(value string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(path.Ext(parsed.Path)) {
+	case ".gif", ".jpeg", ".jpg", ".png", ".webp":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/fcaf/reportpdf/dedupe.go
+++ b/pkg/fcaf/reportpdf/dedupe.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package reportpdf
+
+import "regexp"
+
+// maestroActionScreenshot matches the per-command screenshots the mobile
+// runner stores for one Maestro step, for example
+// obtain_pid_sdjwt_screenshot_1788207713069_action_rzl856vepb.yaml2295819707.png.
+// Each command in a step stores one such shot while the screen barely changes,
+// so the report keeps only the final shot of each burst.
+var maestroActionScreenshot = regexp.MustCompile(
+	`^(.+)_screenshot_[0-9]+_action_[A-Za-z0-9_]+\.yaml[0-9]+\.png$`,
+)
+
+// DeduplicateScreenshots keeps one screenshot per Maestro action burst (the
+// last, which captures the final state of the step) and every non-burst
+// screenshot unchanged. It returns the kept images and the dropped count.
+func DeduplicateScreenshots(images []ImageAsset) ([]ImageAsset, int) {
+	if len(images) < 2 {
+		return images, 0
+	}
+	lastOfBurst := map[string]int{}
+	burstPrefix := make([]string, len(images))
+	for index, image := range images {
+		match := maestroActionScreenshot.FindStringSubmatch(image.Filename)
+		if match == nil {
+			continue
+		}
+		burstPrefix[index] = match[1]
+		lastOfBurst[match[1]] = index
+	}
+
+	kept := make([]ImageAsset, 0, len(images))
+	dropped := 0
+	for index, image := range images {
+		if prefix := burstPrefix[index]; prefix != "" && lastOfBurst[prefix] != index {
+			dropped++
+			continue
+		}
+		kept = append(kept, image)
+	}
+	return kept, dropped
+}

--- a/pkg/fcaf/reportpdf/evidence.go
+++ b/pkg/fcaf/reportpdf/evidence.go
@@ -8,39 +8,28 @@ import (
 	"bytes"
 	"fmt"
 	"image"
-	_ "image/gif"  // register GIF image decoder
-	_ "image/jpeg" // register JPEG image decoder
-	"image/png"
+	"image/draw"
+	_ "image/gif" // register GIF image decoder
+	"image/jpeg"
+	_ "image/png" // register PNG image decoder
 	"net/url"
 	"path"
-	"sort"
 	"strings"
 
-	"github.com/forkbombeu/credimi/pkg/fcaf/engine"
+	xdraw "golang.org/x/image/draw"
 	_ "golang.org/x/image/webp" // register WebP image decoder
 )
 
 const (
 	maxImageBytes  = 50 << 20
 	maxImagePixels = 40_000_000
-)
 
-func ImageReferences(report engine.Report) map[string][]string {
-	references := make(map[string][]string)
-	for key, record := range report.Evidence {
-		seen := map[string]struct{}{}
-		collectImageReferences(record.Value, seen)
-		values := make([]string, 0, len(seen))
-		for value := range seen {
-			values = append(values, value)
-		}
-		sort.Strings(values)
-		if len(values) > 0 {
-			references[key] = values
-		}
-	}
-	return references
-}
+	// pdfImageWidth caps the embedded evidence width. Screenshots render at
+	// most 120 mm wide in the document, so wider sources are downscaled to
+	// keep the generated PDF well under the pipeline-results file size limit.
+	pdfImageWidth  = 700
+	pdfJPEGQuality = 75
+)
 
 func ReferenceFilename(reference string) string {
 	parsed, err := url.Parse(strings.TrimSpace(reference))
@@ -78,44 +67,22 @@ func PrepareImage(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode image: %w", err)
 	}
+	bounds := decoded.Bounds()
+	width, height := bounds.Dx(), bounds.Dy()
+	if width > pdfImageWidth {
+		scale := float64(pdfImageWidth) / float64(width)
+		height = max(1, int(float64(height)*scale))
+		width = pdfImageWidth
+	}
+
+	// Flatten onto white: JPEG has no alpha channel.
+	canvas := image.NewRGBA(image.Rect(0, 0, width, height))
+	draw.Draw(canvas, canvas.Bounds(), image.NewUniform(image.White), image.Point{}, draw.Src)
+	xdraw.CatmullRom.Scale(canvas, canvas.Bounds(), decoded, bounds, xdraw.Over, nil)
+
 	var output bytes.Buffer
-	if err := png.Encode(&output, decoded); err != nil {
-		return nil, fmt.Errorf("encode image as PNG: %w", err)
+	if err := jpeg.Encode(&output, canvas, &jpeg.Options{Quality: pdfJPEGQuality}); err != nil {
+		return nil, fmt.Errorf("encode image as JPEG: %w", err)
 	}
 	return output.Bytes(), nil
-}
-
-func collectImageReferences(value any, seen map[string]struct{}) {
-	switch value := value.(type) {
-	case string:
-		if isImageReference(value) {
-			seen[value] = struct{}{}
-		}
-	case []any:
-		for _, child := range value {
-			collectImageReferences(child, seen)
-		}
-	case []string:
-		for _, child := range value {
-			collectImageReferences(child, seen)
-		}
-	case map[string]any:
-		for _, child := range value {
-			collectImageReferences(child, seen)
-		}
-	}
-}
-
-func isImageReference(value string) bool {
-	parsed, err := url.Parse(strings.TrimSpace(value))
-	if err != nil {
-		return false
-	}
-	extension := strings.ToLower(path.Ext(parsed.Path))
-	switch extension {
-	case ".gif", ".jpeg", ".jpg", ".png", ".webp":
-		return true
-	default:
-		return false
-	}
 }

--- a/pkg/fcaf/reportpdf/model.go
+++ b/pkg/fcaf/reportpdf/model.go
@@ -7,6 +7,7 @@ package reportpdf
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"sort"
@@ -98,13 +99,19 @@ func BuildDocument(input Input) Document {
 		digest := sha256.Sum256(input.RawJSON)
 		document.JSONSHA256 = hex.EncodeToString(digest[:])
 	}
+	images, droppedScreenshots := DeduplicateScreenshots(input.Images)
+	if droppedScreenshots > 0 {
+		document.Warnings = append(
+			document.Warnings,
+			fmt.Sprintf("dropped %d duplicate Maestro action screenshots", droppedScreenshots),
+		)
+	}
 
-	imagesByEvidence := make(map[string][]ImageAsset)
-	for _, image := range input.Images {
-		if strings.TrimSpace(image.EvidenceKey) == "" {
-			continue
+	imagesByFilename := make(map[string]ImageAsset, len(images))
+	for _, image := range images {
+		if _, found := imagesByFilename[image.Filename]; !found {
+			imagesByFilename[image.Filename] = image
 		}
-		imagesByEvidence[image.EvidenceKey] = append(imagesByEvidence[image.EvidenceKey], image)
 	}
 
 	categoryGroups := map[string]map[string]*TestGroup{}
@@ -143,9 +150,31 @@ func BuildDocument(input Input) Document {
 				Record:     record,
 				Referenced: true,
 			})
-			for _, image := range imagesByEvidence[key] {
+		}
+		for _, item := range execution.Evidence {
+			for _, reference := range item.Visual {
+				filename := ReferenceFilename(reference)
+				if filename == "" {
+					continue
+				}
+				image, found := imagesByFilename[filename]
+				if !found {
+					continue
+				}
 				appendImageUnique(&entry.Images, image)
 				assignedImages[image.Filename] = struct{}{}
+			}
+		}
+		// Match the webapp sheet association for tests without bound visual
+		// evidence: a single stored screenshot belongs to every test, and
+		// otherwise screenshots attach by shared words between their
+		// filename and the test id or title.
+		if len(entry.Images) == 0 {
+			for _, image := range images {
+				if len(images) == 1 || screenshotMatchesTest(image.Filename, execution) {
+					appendImageUnique(&entry.Images, image)
+					assignedImages[image.Filename] = struct{}{}
+				}
 			}
 		}
 		group.Tests = append(group.Tests, entry)
@@ -183,42 +212,11 @@ func BuildDocument(input Input) Document {
 		})
 	}
 
-	// Apply the same filename-based association the webapp report uses so
-	// stored screenshots land under the tests whose id or title shares a word
-	// with the screenshot name. Exact evidence references are kept in
-	// addition: a screenshot referenced by an assertion stays attached to
-	// that test even when the name match does not fire.
-	allImages := map[string]ImageAsset{}
-	for _, image := range input.Images {
-		if _, found := allImages[image.Filename]; !found {
-			allImages[image.Filename] = image
-		}
-	}
-	imageNames := make([]string, 0, len(allImages))
-	for filename := range allImages {
-		imageNames = append(imageNames, filename)
-	}
-	sort.Strings(imageNames)
-	for _, filename := range imageNames {
-		image := allImages[filename]
-		matched := false
-		for categoryIndex := range document.Categories {
-			for groupIndex := range document.Categories[categoryIndex].Groups {
-				for testIndex := range document.Categories[categoryIndex].Groups[groupIndex].Tests {
-					if screenshotMatchesTest(filename, document.Categories[categoryIndex].Groups[groupIndex].Tests[testIndex]) {
-						appendImageUnique(
-							&document.Categories[categoryIndex].Groups[groupIndex].Tests[testIndex].Images,
-							image,
-						)
-						matched = true
-					}
-				}
-			}
-		}
-		if !matched {
-			if _, assigned := assignedImages[filename]; !assigned {
-				document.Unassigned = append(document.Unassigned, image)
-			}
+	// Screenshots not associated with any test render once in the evidence
+	// appendix.
+	for _, image := range images {
+		if _, assigned := assignedImages[image.Filename]; !assigned {
+			document.Unassigned = append(document.Unassigned, image)
 		}
 	}
 
@@ -243,12 +241,12 @@ func screenshotLabel(filename string) string {
 	return strings.ToLower(strings.Join(strings.Fields(name), " "))
 }
 
-func screenshotMatchesTest(filename string, test TestEntry) bool {
+func screenshotMatchesTest(filename string, test engine.ExecutedTest) bool {
 	label := screenshotLabel(filename)
 	if label == "" {
 		return false
 	}
-	searchable := strings.ToLower(test.Execution.TestID + " " + test.Execution.Title)
+	searchable := strings.ToLower(test.TestID + " " + test.Title)
 	for _, word := range strings.Fields(label) {
 		if len(word) > 3 && strings.Contains(searchable, word) {
 			return true

--- a/pkg/fcaf/reportpdf/render.go
+++ b/pkg/fcaf/reportpdf/render.go
@@ -29,6 +29,7 @@ type renderer struct {
 	pdf              *fpdf.Fpdf
 	document         Document
 	registeredImages map[string]string
+	figureNumbers    map[string]int
 	section          string
 	sectionColor     [3]int
 	testProgress     string
@@ -68,6 +69,7 @@ func Render(ctx context.Context, document Document) ([]byte, error) {
 		pdf:              pdf,
 		document:         document,
 		registeredImages: map[string]string{},
+		figureNumbers:    map[string]int{},
 	}
 	r.installHeaderAndFooter()
 	if err := r.render(); err != nil {
@@ -643,7 +645,7 @@ func (r *renderer) registerImage(image ImageAsset) (string, float64, float64, bo
 		registeredName = fmt.Sprintf("evidence-image-%d", len(r.registeredImages)+1)
 		r.pdf.RegisterImageOptionsReader(
 			registeredName,
-			fpdf.ImageOptions{ImageType: "PNG"},
+			fpdf.ImageOptions{ImageType: "JPEG"},
 			bytes.NewReader(image.Data),
 		)
 		if r.pdf.Error() != nil {
@@ -678,7 +680,17 @@ func (r *renderer) renderImage(image ImageAsset) {
 	}
 	r.ensureSpace(height + 11)
 	x := pageMargin + (bodyWidth-width)/2
-	r.pdf.ImageOptions(name, x, r.pdf.GetY(), width, height, false, fpdf.ImageOptions{ImageType: "PNG"}, 0, "")
+	r.pdf.ImageOptions(
+		name,
+		x,
+		r.pdf.GetY(),
+		width,
+		height,
+		false,
+		fpdf.ImageOptions{ImageType: "JPEG"},
+		0,
+		"",
+	)
 	r.pdf.SetY(r.pdf.GetY() + height + 1.5)
 	r.pdf.SetFont("SourceCodePro", "", 7)
 	r.pdf.SetTextColor(100, 98, 112)
@@ -691,10 +703,10 @@ func (r *renderer) renderImage(image ImageAsset) {
 }
 
 func (r *renderer) renderImageGrid(images []ImageAsset) {
-	const columns = 2
-	const gap = 8.0
-	const captionHeight = 10.0
-	const maxImageHeight = 110.0
+	const columns = 4
+	const gap = 4.0
+	const captionHeight = 8.0
+	const maxImageHeight = 68.0
 
 	cellWidth := (bodyWidth - float64(columns-1)*gap) / columns
 	rowY := 0.0
@@ -705,11 +717,10 @@ func (r *renderer) renderImageGrid(images []ImageAsset) {
 		evidenceKey string
 	}
 	figures := make([]figure, 0, len(images))
-
 	for i, image := range images {
 		col := i % columns
 		if col == 0 {
-			r.ensureSpace(maxImageHeight + captionHeight + 8)
+			r.ensureSpace(maxImageHeight + captionHeight + 6)
 			rowY = r.pdf.GetY()
 		}
 
@@ -720,24 +731,48 @@ func (r *renderer) renderImageGrid(images []ImageAsset) {
 		scale := min(cellWidth/width, maxImageHeight/height)
 		drawW := width * scale
 		drawH := height * scale
-
-		r.evidenceCount++
+		figureNumber, seen := r.figureNumbers[image.Filename]
+		if !seen {
+			r.evidenceCount++
+			figureNumber = r.evidenceCount
+			r.figureNumbers[image.Filename] = figureNumber
+		}
 		figures = append(figures, figure{
-			number:      r.evidenceCount,
+			number:      figureNumber,
 			filename:    image.Filename,
 			evidenceKey: image.EvidenceKey,
 		})
 
 		x := pageMargin + float64(col)*(cellWidth+gap) + (cellWidth-drawW)/2
-		r.pdf.ImageOptions(name, x, rowY, drawW, drawH, false, fpdf.ImageOptions{ImageType: "PNG"}, 0, "")
+		r.pdf.ImageOptions(
+			name,
+			x,
+			rowY,
+			drawW,
+			drawH,
+			false,
+			fpdf.ImageOptions{ImageType: "JPEG"},
+			0,
+			"",
+		)
 
-		r.pdf.SetXY(pageMargin+float64(col)*(cellWidth+gap), rowY+maxImageHeight+1.5)
-		r.pdf.SetFont("SourceCodePro", "", 7)
+		r.pdf.SetXY(pageMargin+float64(col)*(cellWidth+gap), rowY+maxImageHeight+1.0)
+		r.pdf.SetFont("SourceCodePro", "", 6.5)
 		r.pdf.SetTextColor(100, 98, 112)
-		r.pdf.CellFormat(cellWidth, 3.5, fmt.Sprintf("Evidence %d", r.evidenceCount), "", 0, "C", false, 0, "")
+		r.pdf.CellFormat(
+			cellWidth,
+			3,
+			fmt.Sprintf("Evidence %d", figureNumber),
+			"",
+			0,
+			"C",
+			false,
+			0,
+			"",
+		)
 
-		if col == columns-1 {
-			r.pdf.SetY(rowY + maxImageHeight + captionHeight + 3)
+		if col == columns-1 || i == len(images)-1 {
+			r.pdf.SetY(rowY + maxImageHeight + captionHeight + 2)
 		}
 	}
 

--- a/pkg/fcaf/reportpdf/reportpdf_test.go
+++ b/pkg/fcaf/reportpdf/reportpdf_test.go
@@ -62,7 +62,7 @@ func TestLoadMaterialsFindsCatalogAndSource(t *testing.T) {
 	require.NotEmpty(t, sources[testID].ExpectedResults)
 }
 
-func TestBuildDocumentAssociatesOnlyExactEvidenceImages(t *testing.T) {
+func TestBuildDocumentAttachesPerTestVisualEvidence(t *testing.T) {
 	report := engine.Report{
 		ExecutedTests: []engine.ExecutedTest{
 			{
@@ -71,6 +71,11 @@ func TestBuildDocumentAssociatesOnlyExactEvidenceImages(t *testing.T) {
 				Assertions: []engine.ExecutedCheck{
 					{ID: "visual", Status: "passed", EvidenceKeys: []string{"visual_evidence"}},
 				},
+				Evidence: []engine.ExecutedEvidence{{
+					Name:       "visual_evidence",
+					SourceNode: "pipeline.dcql.cryptography",
+					Visual:     []string{"https://app.test/cryptography.png"},
+				}},
 			},
 			{
 				TestID: "WS_RP_TEST__002",
@@ -81,7 +86,10 @@ func TestBuildDocumentAssociatesOnlyExactEvidenceImages(t *testing.T) {
 			},
 		},
 		Evidence: engine.EvidenceMap{
-			"visual_evidence":   {Type: "json.array", Value: []any{"https://app.test/visual.png"}},
+			"visual_evidence": {
+				Type:  "json.array",
+				Value: []any{"https://app.test/cryptography.png"},
+			},
 			"protocol_evidence": {Type: "json.object", Value: map[string]any{"status": "failed"}},
 		},
 	}
@@ -90,76 +98,117 @@ func TestBuildDocumentAssociatesOnlyExactEvidenceImages(t *testing.T) {
 		Report:  report,
 		RawJSON: []byte(`{"status":"failed"}`),
 		Images: []ImageAsset{
-			{EvidenceKey: "visual_evidence", Filename: "visual.png", Data: []byte("image")},
+			{Filename: "cryptography.png", Data: []byte("image")},
 			{Filename: "unassigned.png", Data: []byte("image")},
 		},
 	})
 
 	require.Len(t, document.Categories, 1)
 	require.Len(t, document.Categories[0].Groups[0].Tests[0].Images, 1)
+	require.Equal(
+		t,
+		"cryptography.png",
+		document.Categories[0].Groups[0].Tests[0].Images[0].Filename,
+	)
+	// The other test cited no visual evidence, so it gets no screenshot even
+	// though the flat report evidence map shares its name.
 	require.Empty(t, document.Categories[0].Groups[0].Tests[1].Images)
 	require.Len(t, document.Unassigned, 1)
 	require.NotEmpty(t, document.JSONSHA256)
 }
 
-func TestBuildDocumentFallsBackToFilenameAssociation(t *testing.T) {
+func TestBuildDocumentFallsBackToWordMatchAssociation(t *testing.T) {
 	report := engine.Report{
 		ExecutedTests: []engine.ExecutedTest{
 			{
 				TestID: "WS_RP_DM_Credentialmetadata_Documentnumber__001",
-				Status: "failed",
+				Status: "passed",
 			},
 			{
-				TestID: "WS_RP_DM_AddressData_Emailaddress__001",
-				Status: "failed",
+				TestID: "WS_RP_IA_Engagement__001",
+				Status: "passed",
 			},
-		},
-		Evidence: engine.EvidenceMap{
-			// visual_evidence resolved to null because the producing step failed.
-			"visual_evidence": {Type: "json.array", Value: nil},
 		},
 	}
 
 	document := BuildDocument(Input{
 		Report: report,
 		Images: []ImageAsset{
-			{Filename: "getcredential_generic_credential_without_authentication_0004_credential_added_x.png", Data: []byte("image")},
-			{Filename: "onboarding_1_fcaf_onboarding_complete_y.png", Data: []byte("image")},
+			{Filename: "scenario_obtain_pid_credential_added_x.png", Data: []byte("image")},
+			{Filename: "scenario_engagement_complete_y.png", Data: []byte("image")},
 		},
 	})
 
-	require.Len(t, document.Categories, 1)
-	require.Len(t, document.Categories[0].Groups, 2)
-	// Subgroups sort alphabetically: AddressData before Credentialmetadata.
-	require.Empty(t, document.Categories[0].Groups[0].Tests[0].Images)
-	// "credential" word overlaps the Credentialmetadata test id.
-	require.Len(t, document.Categories[0].Groups[1].Tests[0].Images, 1)
-	require.Len(t, document.Unassigned, 1)
-}
-
-func TestImageReferencesAndPreparation(t *testing.T) {
-	report := engine.Report{Evidence: engine.EvidenceMap{
-		"visual": {
-			Value: map[string]any{
-				"screenshots": []any{
-					"https://app.test/api/files/pipeline_results/record/step.png?token=x",
-					"https://app.test/result.json",
-				},
-			},
-		},
-	}}
-
-	references := ImageReferences(report)
+	// "credential" matches the Credentialmetadata test id; "engagement"
+	// matches the Engagement test id — mirroring the webapp sheet.
+	require.Len(t, document.Categories[0].Groups[0].Tests[0].Images, 1)
 	require.Equal(
 		t,
-		[]string{"https://app.test/api/files/pipeline_results/record/step.png?token=x"},
-		references["visual"],
+		"scenario_obtain_pid_credential_added_x.png",
+		document.Categories[0].Groups[0].Tests[0].Images[0].Filename,
 	)
-	require.Equal(t, "step.png", ReferenceFilename(references["visual"][0]))
+	require.Len(t, document.Categories[1].Groups[0].Tests[0].Images, 1)
+	require.Equal(
+		t,
+		"scenario_engagement_complete_y.png",
+		document.Categories[1].Groups[0].Tests[0].Images[0].Filename,
+	)
+	require.Empty(t, document.Unassigned)
+}
+
+func TestBuildDocumentKeepsScenarioEvidenceSeparate(t *testing.T) {
+	report := engine.Report{
+		ExecutedTests: []engine.ExecutedTest{
+			{
+				TestID: "WS_RP_MS_Cryptography__001",
+				Status: "passed",
+				Evidence: []engine.ExecutedEvidence{{
+					Name:       "visual_evidence",
+					SourceNode: "pipeline.dcql.cryptography",
+					Visual:     []string{"https://app.test/cryptography.png"},
+				}},
+			},
+			{
+				TestID: "WS_RP_MS_TrustMechanisms__001",
+				Status: "passed",
+				Evidence: []engine.ExecutedEvidence{{
+					Name:       "visual_evidence",
+					SourceNode: "pipeline.dcql.trust-mechanisms",
+					Visual:     []string{"https://app.test/trust.png"},
+				}},
+			},
+		},
+	}
+
+	document := BuildDocument(Input{
+		Report: report,
+		Images: []ImageAsset{
+			{Filename: "cryptography.png", Data: []byte("image")},
+			{Filename: "trust.png", Data: []byte("image")},
+		},
+	})
+
+	// Both scenarios share the evidence name visual_evidence; each test still
+	// receives only its own scenario's screenshot.
+	groups := document.Categories[0].Groups
+	require.Len(t, groups[0].Tests[0].Images, 1)
+	require.Equal(t, "cryptography.png", groups[0].Tests[0].Images[0].Filename)
+	require.Len(t, groups[1].Tests[0].Images, 1)
+	require.Equal(t, "trust.png", groups[1].Tests[0].Images[0].Filename)
+	require.Empty(t, document.Unassigned)
+}
+
+func TestReferenceFilenameAndPreparation(t *testing.T) {
+	require.Equal(
+		t,
+		"step.png",
+		ReferenceFilename("https://app.test/api/files/pipeline_results/record/step.png?token=x"),
+	)
+	require.Equal(t, "", ReferenceFilename("https://app.test/"))
 
 	prepared, err := PrepareImage(testPNG(t))
 	require.NoError(t, err)
-	require.True(t, bytes.HasPrefix(prepared, []byte("\x89PNG")))
+	require.True(t, bytes.HasPrefix(prepared, []byte{0xFF, 0xD8}))
 
 	_, err = PrepareImage([]byte("not an image"))
 	require.Error(t, err)
@@ -177,7 +226,11 @@ func TestRenderEmbedsVisualEvidenceImage(t *testing.T) {
 				TestID: "WS_RP_DM_AddressData_Emailaddress_PID_IETF-sd-jwt-vc_001",
 				Status: "passed",
 				Assertions: []engine.ExecutedCheck{
-					{ID: "email_present", Status: "passed", EvidenceKeys: []string{"visual_evidence"}},
+					{
+						ID:           "email_present",
+						Status:       "passed",
+						EvidenceKeys: []string{"visual_evidence"},
+					},
 				},
 			},
 		},
@@ -185,7 +238,8 @@ func TestRenderEmbedsVisualEvidenceImage(t *testing.T) {
 			"visual_evidence": {Type: "json.array", Value: []any{"https://app.test/visual.png"}},
 		},
 	}
-	imageData := testPNG(t)
+	imageData, err := PrepareImage(testPNG(t))
+	require.NoError(t, err)
 	document := BuildDocument(Input{
 		Report:  report,
 		RawJSON: []byte(`{"status":"passed"}`),
@@ -241,6 +295,59 @@ func TestRenderProducesMultipagePDF(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, bytes.HasPrefix(data, []byte("%PDF-")))
 	require.Greater(t, bytes.Count(data, []byte("/Type /Page")), 2)
+}
+
+func TestDeduplicateScreenshotsKeepsLastPerBurst(t *testing.T) {
+	images := []ImageAsset{
+		{
+			Filename: "pid_mdoc_8f915369_obtain_pid_mdoc_screenshot_1788208561028_action_a1.yaml1.png",
+		},
+		{Filename: "pid_mdoc_8f915369_obtain_pid_mdoc_credential_added_x1.png"},
+		{
+			Filename: "pid_mdoc_8f915369_obtain_pid_mdoc_screenshot_1788208562014_action_a2.yaml1.png",
+		},
+		{
+			Filename: "engagement_4bb0f83a_obtain_pid_sdjwt_screenshot_1788207713069_action_b1.yaml2.png",
+		},
+		{
+			Filename: "pid_mdoc_8f915369_obtain_pid_mdoc_screenshot_1788208562614_action_a3.yaml1.png",
+		},
+		{
+			Filename: "engagement_4bb0f83a_obtain_pid_sdjwt_screenshot_1788207713943_action_b2.yaml2.png",
+		},
+	}
+
+	kept, dropped := DeduplicateScreenshots(images)
+
+	require.Equal(t, 3, dropped)
+	require.Len(t, kept, 3)
+	require.Equal(
+		t,
+		"pid_mdoc_8f915369_obtain_pid_mdoc_credential_added_x1.png",
+		kept[0].Filename,
+	)
+	require.Equal(
+		t,
+		"pid_mdoc_8f915369_obtain_pid_mdoc_screenshot_1788208562614_action_a3.yaml1.png",
+		kept[1].Filename,
+	)
+	require.Equal(
+		t,
+		"engagement_4bb0f83a_obtain_pid_sdjwt_screenshot_1788207713943_action_b2.yaml2.png",
+		kept[2].Filename,
+	)
+}
+
+func TestDeduplicateScreenshotsLeavesNonBurstImagesAlone(t *testing.T) {
+	images := []ImageAsset{
+		{Filename: "onboard_reference_wallet_fcaf_onboarding_complete_y.png"},
+		{Filename: "dcql_cryptography_1a488a33_exercise_wallet_cryptography_x.png"},
+	}
+
+	kept, dropped := DeduplicateScreenshots(images)
+
+	require.Equal(t, 0, dropped)
+	require.Len(t, kept, 2)
 }
 
 func testPNG(t *testing.T) []byte {

--- a/pkg/internal/apis/handlers/credential_handlers.go
+++ b/pkg/internal/apis/handlers/credential_handlers.go
@@ -29,8 +29,8 @@ var CredentialTemporalInternalRoutes routing.RouteGroup = routing.RouteGroup{
 	BaseURL:                "/api/credential",
 	AuthenticationRequired: false,
 	Middlewares: []*hook.Handler[*core.RequestEvent]{
-		middlewares.RequireInternalAdminAPIKey(),
 		{Func: middlewares.ErrorHandlingMiddleware},
+		middlewares.RequireInternalAdminAPIKey(),
 	},
 	Routes: []routing.RouteDefinition{
 		{

--- a/pkg/internal/apis/handlers/mobile_runners_handlers.go
+++ b/pkg/internal/apis/handlers/mobile_runners_handlers.go
@@ -111,8 +111,8 @@ var MobileRunnersTemporalInternalRoutes routing.RouteGroup = routing.RouteGroup{
 	BaseURL:                "/api/mobile-runner",
 	AuthenticationRequired: false,
 	Middlewares: []*hook.Handler[*core.RequestEvent]{
-		middlewares.RequireInternalAdminAPIKey(),
 		{Func: middlewares.ErrorHandlingMiddleware},
+		middlewares.RequireInternalAdminAPIKey(),
 	},
 	Routes: []routing.RouteDefinition{
 		{

--- a/pkg/internal/apis/handlers/pipeline_fcaf_pdf.go
+++ b/pkg/internal/apis/handlers/pipeline_fcaf_pdf.go
@@ -92,36 +92,37 @@ func loadPipelineFCAFReportImages(
 			storedFilenames = append(storedFilenames, filename)
 		}
 	}
-	if len(storedFilenames) == 0 {
+	if len(storedFilenames) == 0 && len(report.ExecutedTests) == 0 {
 		return nil, nil, nil
 	}
 
-	evidenceKeysByFilename := map[string][]string{}
 	warnings := []string{}
-	for evidenceKey, references := range reportpdf.ImageReferences(report) {
-		for _, reference := range references {
-			filename := reportpdf.ReferenceFilename(reference)
-			if filename == "" {
-				warnings = append(warnings, "invalid visual evidence reference for "+evidenceKey)
-				continue
+	seenWarnings := map[string]struct{}{}
+	for _, execution := range report.ExecutedTests {
+		for _, item := range execution.Evidence {
+			for _, reference := range item.Visual {
+				filename := reportpdf.ReferenceFilename(reference)
+				if filename == "" {
+					continue
+				}
+				if _, found := storedSet[filename]; found {
+					continue
+				}
+				if _, warned := seenWarnings[filename]; warned {
+					continue
+				}
+				seenWarnings[filename] = struct{}{}
+				warnings = append(warnings, fmt.Sprintf(
+					"visual evidence %s was not stored on this pipeline result",
+					filename,
+				))
 			}
-			if _, found := storedSet[filename]; !found {
-				warnings = append(
-					warnings,
-					fmt.Sprintf(
-						"visual evidence %s was not stored on this pipeline result",
-						filename,
-					),
-				)
-				continue
-			}
-			evidenceKeysByFilename[filename] = appendUniqueString(
-				evidenceKeysByFilename[filename],
-				evidenceKey,
-			)
 		}
 	}
 
+	if len(storedFilenames) == 0 {
+		return nil, warnings, nil
+	}
 	fileSystem, err := app.NewFilesystem()
 	if err != nil {
 		return nil, warnings, fmt.Errorf("open PocketBase filesystem: %w", err)
@@ -160,18 +161,7 @@ func loadPipelineFCAFReportImages(
 			continue
 		}
 
-		evidenceKeys := evidenceKeysByFilename[filename]
-		if len(evidenceKeys) == 0 {
-			images = append(images, reportpdf.ImageAsset{Filename: filename, Data: prepared})
-			continue
-		}
-		for _, evidenceKey := range evidenceKeys {
-			images = append(images, reportpdf.ImageAsset{
-				EvidenceKey: evidenceKey,
-				Filename:    filename,
-				Data:        prepared,
-			})
-		}
+		images = append(images, reportpdf.ImageAsset{Filename: filename, Data: prepared})
 	}
 
 	return images, warnings, nil
@@ -225,17 +215,7 @@ func pipelineFCAFReportMetadata(
 			)
 		}
 	}
-
 	return metadata, warnings
-}
-
-func appendUniqueString(values []string, value string) []string {
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
-	}
-	return append(values, value)
 }
 
 func firstNonBlank(values ...string) string {

--- a/pkg/internal/apis/handlers/pipeline_fcaf_pdf_test.go
+++ b/pkg/internal/apis/handlers/pipeline_fcaf_pdf_test.go
@@ -89,7 +89,7 @@ func TestUpdatePipelineExecutionFCAFReportStoresJSONAndPDF(t *testing.T) {
 	require.Contains(t, string(pdf), "%PDF-")
 }
 
-func TestLoadPipelineFCAFReportImagesUsesExactEvidenceKey(t *testing.T) {
+func TestLoadPipelineFCAFReportImagesLoadsStoredScreenshots(t *testing.T) {
 	app := setupPipelineApp(t)
 	defer app.Cleanup()
 	ensureStepScreenshotField(t, app)
@@ -107,20 +107,47 @@ func TestLoadPipelineFCAFReportImagesUsesExactEvidenceKey(t *testing.T) {
 	filenames := record.GetStringSlice("maestro_screenshots")
 	require.Len(t, filenames, 1)
 	filename := filenames[0]
-	report := engine.Report{Evidence: engine.EvidenceMap{
-		"visual_evidence": {
-			Value: []any{
-				"https://app.test/api/files/pipeline_results/" + record.Id + "/" + filename,
+	report := engine.Report{ExecutedTests: []engine.ExecutedTest{{
+		TestID: "test-1",
+		Evidence: []engine.ExecutedEvidence{
+			{
+				Name: "visual_evidence",
+				Visual: []string{
+					"https://app.test/api/files/pipeline_results/" + record.Id + "/" + filename,
+				},
 			},
 		},
-	}}
+	}}}
 	images, warnings, err := loadPipelineFCAFReportImages(app, record, report)
 	require.NoError(t, err)
 	require.Empty(t, warnings)
 	require.Len(t, images, 1)
-	require.Equal(t, "visual_evidence", images[0].EvidenceKey)
 	require.Equal(t, filename, images[0].Filename)
 	require.NotEmpty(t, images[0].Data)
+}
+
+func TestLoadPipelineFCAFReportImagesWarnsForUnstoredVisualReference(t *testing.T) {
+	app := setupPipelineApp(t)
+	defer app.Cleanup()
+	ensureStepScreenshotField(t, app)
+
+	record := createFCAFReportPipelineResult(t, app, "workflow-missing", "run-missing")
+	report := engine.Report{ExecutedTests: []engine.ExecutedTest{{
+		TestID: "test-1",
+		Evidence: []engine.ExecutedEvidence{
+			{
+				Name: "visual_evidence",
+				Visual: []string{
+					"https://app.test/api/files/pipeline_results/" + record.Id + "/missing.png",
+				},
+			},
+		},
+	}}}
+	images, warnings, err := loadPipelineFCAFReportImages(app, record, report)
+	require.NoError(t, err)
+	require.Empty(t, images)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "missing.png was not stored")
 }
 
 func TestUpdatePipelineExecutionFCAFReportPreservesJSONWhenPDFGenerationFails(t *testing.T) {

--- a/pkg/internal/apis/handlers/verifier_handlers.go
+++ b/pkg/internal/apis/handlers/verifier_handlers.go
@@ -24,8 +24,8 @@ var VerifierTemporalInternalRoutes routing.RouteGroup = routing.RouteGroup{
 	BaseURL:                "/api/verifier",
 	AuthenticationRequired: false,
 	Middlewares: []*hook.Handler[*core.RequestEvent]{
-		middlewares.RequireInternalAdminAPIKey(),
 		{Func: middlewares.ErrorHandlingMiddleware},
+		middlewares.RequireInternalAdminAPIKey(),
 	},
 	Routes: []routing.RouteDefinition{
 		{

--- a/pkg/workflowengine/pipeline/mobile_automation_hooks.go
+++ b/pkg/workflowengine/pipeline/mobile_automation_hooks.go
@@ -303,11 +303,13 @@ func markExternalInstallSteps(
 			continue
 		}
 
-		category, err := fetchMobileActionCategory(
-			ctx,
-			appURL,
-			workflowengine.AsString(step.With.Payload["action_id"]),
-		)
+		actionID, _ := step.With.Payload["action_id"].(string)
+		if strings.TrimSpace(actionID) == "" {
+			// Inline action_code steps have no stored action to categorize;
+			// resolving a missing identifier would query "<nil>".
+			continue
+		}
+		category, err := fetchMobileActionCategory(ctx, appURL, actionID)
 		if err != nil {
 			return err
 		}

--- a/pkg/workflowengine/pipeline/mobile_automation_hooks_test.go
+++ b/pkg/workflowengine/pipeline/mobile_automation_hooks_test.go
@@ -3045,3 +3045,70 @@ func mobileAutomationSetupSteps() []pipeline.StepDefinition {
 		},
 	}
 }
+
+func testMarkExternalInstallStepsWorkflow(
+	ctx workflow.Context,
+	steps []pipeline.StepDefinition,
+) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Minute,
+	})
+	return markExternalInstallSteps(ctx, &steps, map[string]any{"app_url": "https://example.test"})
+}
+
+// TestMarkExternalInstallStepsSkipsInlineActionCodeSteps guards against
+// resolving the literal "<nil>" identifier for sentinel steps that carry an
+// inline action_code and no stored action_id.
+func TestMarkExternalInstallStepsSkipsInlineActionCodeSteps(t *testing.T) {
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterWorkflowWithOptions(
+		testMarkExternalInstallStepsWorkflow,
+		workflow.RegisterOptions{Name: "test-mark-external-install-steps"},
+	)
+	httpActivity := registerInternalHTTPActivity(env)
+	httpCalls := 0
+	env.OnActivity(httpActivity.Name(), mock.Anything, mock.Anything).
+		Return(workflowengine.ActivityResult{Output: map[string]any{
+			"body": map[string]any{"record": map[string]any{"category": "verify-credential"}},
+		}}, nil).
+		Run(func(_ mock.Arguments) { httpCalls++ })
+
+	steps := []pipeline.StepDefinition{
+		{
+			StepSpec: pipeline.StepSpec{
+				ID:  "inline-code",
+				Use: "mobile-automation",
+				With: pipeline.StepInputs{
+					Payload: map[string]any{
+						"version_id":  "installed_from_external_source",
+						"action_code": "appId: eu.europa.ec.euidi",
+					},
+				},
+			},
+		},
+		{
+			StepSpec: pipeline.StepSpec{
+				ID:  "stored-action",
+				Use: "mobile-automation",
+				With: pipeline.StepInputs{
+					Payload: map[string]any{
+						"version_id": "installed_from_external_source",
+						"action_id":  "fcaf-1/eudiw-beta-wallet/fcaf-engagement-haip-vp",
+					},
+				},
+			},
+		},
+	}
+
+	env.ExecuteWorkflow("test-mark-external-install-steps", steps)
+
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, httpCalls, "only the stored-action step may resolve a category")
+	require.False(
+		t,
+		steps[0].With.Config["detect_external_install"] == true,
+		"inline action_code steps must not enable external install detection",
+	)
+}

--- a/webapp/src/lib/pipeline-form/steps/wallet-action/index.ts
+++ b/webapp/src/lib/pipeline-form/steps/wallet-action/index.ts
@@ -77,7 +77,7 @@ export const walletActionStepConfig: TypedConfig<'mobile-automation', WalletActi
 
 	initForm: (opts) => new WalletActionStepForm(opts),
 
-	serialize: ({ action, version, runner }) => {
+	serialize: ({ action, version, runner, parameters }) => {
 		type StepData = PipelineStepData<PipelineStepByType<'mobile-automation'>>;
 		const _with: StepData = {
 			action_id: getPath(action),
@@ -86,7 +86,11 @@ export const walletActionStepConfig: TypedConfig<'mobile-automation', WalletActi
 		if (runner !== GLOBAL_RUNNER) {
 			_with.runner_id = runner.path;
 		}
-		if (action.code.includes('${DL}') || action.code.includes('${deeplink}')) {
+		if (parameters && Object.keys(parameters).length > 0) {
+			// Keep the exact bound parameters so editing a step never drops
+			// values like deeplink references or custom action variables.
+			_with.parameters = parameters;
+		} else if (action.code.includes('${DL}') || action.code.includes('${deeplink}')) {
 			_with.parameters = {
 				deeplink: '<deeplink-placeholder>'
 			};
@@ -157,6 +161,12 @@ export const walletActionStepConfig: TypedConfig<'mobile-automation', WalletActi
 
 		const wallet: HubItem = await pb.collection('hub_items').getOne(action.wallet);
 
-		return { wallet, version, action, runner };
+		return {
+			wallet,
+			version,
+			action,
+			runner,
+			parameters: data.parameters as { [key: string]: string } | undefined
+		};
 	}
 };

--- a/webapp/src/lib/pipeline-form/steps/wallet-action/types.ts
+++ b/webapp/src/lib/pipeline-form/steps/wallet-action/types.ts
@@ -6,8 +6,10 @@ import { isExecutionTarget, type ExecutionTarget } from '$pipeline-form/executio
 
 import type { WalletActionsResponse } from '@/pocketbase/types';
 
-export type WalletActionStepData = ExecutionTarget & { action: WalletActionsResponse };
-
+export type WalletActionStepData = ExecutionTarget & {
+	action: WalletActionsResponse;
+	parameters?: { [key: string]: string };
+};
 export function isWalletActionStepData(value: unknown): value is WalletActionStepData {
 	if (!isExecutionTarget(value) || !('action' in value)) return false;
 	const action = (value as WalletActionStepData).action;

--- a/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
+++ b/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
@@ -37,14 +37,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		validator?: string;
 	};
 
+	type ExecutedEvidence = {
+		name?: string;
+		source_node?: string;
+		visual?: string[];
+	};
+
 	type TestResult = {
 		test_id?: string;
 		title?: string;
 		status?: string;
 		assertions?: Array<{ id?: string; status?: string; message?: string; validator?: string }>;
 		validators?: Validator[];
+		evidence?: ExecutedEvidence[];
 	};
-
 	type Report = {
 		status?: string;
 		suite?: string;
@@ -82,7 +88,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			.replace(/\s+/g, ' ')
 			.trim();
 	}
-
 	function uniqueScreenshots(screenshots: Screenshot[]): Screenshot[] {
 		const seen = new SvelteSet<string>();
 		return screenshots.filter((screenshot) => {
@@ -93,8 +98,49 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		});
 	}
 
+	function dedupeBurstScreenshots(screenshots: Screenshot[]): Screenshot[] {
+		const burst = /^(.+)_screenshot_\d+_action_[A-Za-z0-9_]+\.yaml\d+\.png$/;
+		const lastOfBurst = new Map<string, Screenshot>();
+		for (const screenshot of screenshots) {
+			const filename = screenshot.url.split('?')[0].split('/').pop() ?? '';
+			const match = burst.exec(decodeURIComponent(filename));
+			if (match) lastOfBurst.set(match[1], screenshot);
+		}
+		return screenshots.filter((screenshot) => {
+			const filename = screenshot.url.split('?')[0].split('/').pop() ?? '';
+			const match = burst.exec(decodeURIComponent(filename));
+			if (!match) return true;
+			return lastOfBurst.get(match[1]) === screenshot;
+		});
+	}
+
+	function visualUrlsForTest(test: TestResult): string[] {
+		const urls: string[] = [];
+		const seen = new Set<string>();
+		for (const item of test.evidence ?? []) {
+			for (const url of item.visual ?? []) {
+				const normalized = url.split('?')[0];
+				if (!seen.has(normalized)) {
+					seen.add(normalized);
+					urls.push(normalized);
+				}
+			}
+		}
+		return urls;
+	}
+
 	function screenshotsForTest(screenshots: Screenshot[], test: TestResult): Screenshot[] {
 		if (screenshots.length === 0) return [];
+
+		// Prefer the per-test visual evidence recorded by the report engine:
+		// the flat evidence map keeps only one record per evidence name.
+		const visual = visualUrlsForTest(test);
+		if (visual.length > 0) {
+			const byUrl = new Map(screenshots.map((s) => [s.url.split('?')[0], s]));
+			return visual
+				.map((url) => byUrl.get(url))
+				.filter((screenshot): screenshot is Screenshot => Boolean(screenshot));
+		}
 		if (screenshots.length === 1) return screenshots;
 
 		const searchable = `${test.test_id ?? ''} ${test.title ?? ''}`.toLowerCase();
@@ -287,13 +333,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			{#await reportPromise then report}
 				<div class="pb-6">
 					{#if report}
-						{@const evidenceScreenshots = evidenceScreenshotUrls(report)}
-						{@const allScreenshots = uniqueScreenshots(
-							[...new Set([...maestroScreenshotUrls, ...evidenceScreenshots])].map(
-								(url) => ({
+						{@const evidenceScreenshots = evidenceScreenshotUrls(report.evidence)}
+						{@const allScreenshots = dedupeBurstScreenshots(
+							uniqueScreenshots(
+								[
+									...new Set([...maestroScreenshotUrls, ...evidenceScreenshots])
+								].map((url) => ({
 									url,
 									label: screenshotLabel(url)
-								})
+								}))
 							)
 						)}
 						{@const executedTests = report.executed_tests ?? []}


### PR DESCRIPTION
## Summary

- **Report evidence is per test now.** The engine records each executed test's own evidence (including its visual screenshot URLs) in `executed_tests[].evidence[]`, so the flat evidence map's last-write-wins collision no longer shows one scenario's screenshots for every test. The webapp sheet and the PDF use the same association (per-test visuals first, filename word-match fallback, burst dedupe).
- **The FCAF report PDF generates again.** Evidence screenshots are downscaled and JPEG-encoded, the `fcaf_report_pdf` field got an explicit 50 MiB limit (PocketBase's `maxSize: 0` is the 5 MiB default, which silently rejected every PDF), Maestro action-burst screenshots render once, and each image draws once per document with stable figure numbers.
- **The happy-flow pipeline's wallet steps are editor-compatible.** The 11 inline `action_code` steps became references to two synced wallet actions (`fcaf-exercise-wallet-generic`, `fcaf-submit-request-object-by-value`) defined in `config_templates/fcaf/imports/`. The editor now round-trips arbitrary step `parameters` instead of dropping everything except `deeplink`. Synced wallet actions are published automatically, and the dev Temporal blob limit was raised for the aggregate report event.

## Notes

- The ~90 fragmented one-test DCQL scenarios in the complete-validation aggregate still use inline `action_code` and remain flagged in the editor; converting them needs their distinct flow templates extracted first (recorded in `pkg/fcaf/MEMORY.md`).
- The wallet record itself is created outside `fcaf sync`, so publishing it stays a one-time manual step per environment.

## Validation

- `make test` 1276/1280 (4 skipped), scoped golangci-lint 0 issues, `make fmt`/`go mod tidy -diff`/`go mod verify` clean
- webapp: `bun run check` 0 errors, `bun run test:unit` 173 passing, lint clean (pre-existing `project.inlang` warnings only)
- Verified end-to-end on a live demo run: PDF stores automatically (3.8 MB / 108 pages), per-test visual evidence matches the webapp report exactly
