### PR TITLE
fix(fcaf): dedupe cloud runner step screenshots in reports

### DIFF
--- a/pkg/fcaf/reportpdf/dedupe.go
+++ b/pkg/fcaf/reportpdf/dedupe.go
@@ -6,16 +6,17 @@ package reportpdf
 
 import "regexp"
 
-// maestroActionScreenshot matches the per-command screenshots the mobile
-// runner stores for one Maestro step, for example
-// obtain_pid_sdjwt_screenshot_1788207713069_action_rzl856vepb.yaml2295819707.png.
-// Each command in a step stores one such shot while the screen barely changes,
-// so the report keeps only the final shot of each burst.
-var maestroActionScreenshot = regexp.MustCompile(
-	`^(.+)_screenshot_[0-9]+_action_[A-Za-z0-9_]+\.yaml[0-9]+\.png$`,
+// maestroBurstScreenshot matches the per-command screenshots a mobile runner
+// stores for one Maestro flow. Each command in a flow stores one such shot
+// while the screen barely changes, so the report keeps only the final shot of
+// each burst. Two runner naming schemes exist:
+//   - local runner: obtain_pid_sdjwt_screenshot_1788207713069_action_rzl856vepb.yaml2295819707.png
+//   - cloud runner: obtain_pid_sdjwt_step_004_tap_on_element_eudi_wallet_c0pcg1tjd1.png
+var maestroBurstScreenshot = regexp.MustCompile(
+	`^(.+)(?:_screenshot_[0-9]+_action_[A-Za-z0-9_]+\.yaml[0-9]+|_step_[0-9]+_[A-Za-z0-9_]+)\.png$`,
 )
 
-// DeduplicateScreenshots keeps one screenshot per Maestro action burst (the
+// DeduplicateScreenshots keeps one screenshot per Maestro command burst (the
 // last, which captures the final state of the step) and every non-burst
 // screenshot unchanged. It returns the kept images and the dropped count.
 func DeduplicateScreenshots(images []ImageAsset) ([]ImageAsset, int) {
@@ -25,7 +26,7 @@ func DeduplicateScreenshots(images []ImageAsset) ([]ImageAsset, int) {
 	lastOfBurst := map[string]int{}
 	burstPrefix := make([]string, len(images))
 	for index, image := range images {
-		match := maestroActionScreenshot.FindStringSubmatch(image.Filename)
+		match := maestroBurstScreenshot.FindStringSubmatch(image.Filename)
 		if match == nil {
 			continue
 		}

--- a/pkg/fcaf/reportpdf/reportpdf_test.go
+++ b/pkg/fcaf/reportpdf/reportpdf_test.go
@@ -363,3 +363,33 @@ func testPNG(t *testing.T) []byte {
 	require.NoError(t, png.Encode(&output, img))
 	return output.Bytes()
 }
+
+func TestDeduplicateScreenshotsKeepsLastPerCloudBurst(t *testing.T) {
+	images := []ImageAsset{
+		{Filename: "engagement_haip_vp_4bb0f83a_obtain_pid_sdjwt_step_004_tap_on_element_eudi_wallet_a.png"},
+		{Filename: "engagement_haip_vp_4bb0f83a_obtain_pid_sdjwt_step_005_tap_on_element_just_once_b.png"},
+		{Filename: "engagement_haip_vp_4bb0f83a_obtain_pid_sdjwt_step_006_tap_on_element_always_c.png"},
+		{Filename: "engagement_haip_vp_4bb0f83a_obtain_pid_sdjwt_credential_added_d.png"},
+		{Filename: "engagement_haip_vp_4bb0f83a_invoke_wallet_with_haip_vp_fcaf_engagement_haip_vp_invoked_e.png"},
+	}
+
+	kept, dropped := DeduplicateScreenshots(images)
+
+	require.Equal(t, 2, dropped)
+	require.Len(t, kept, 3)
+	require.Equal(
+		t,
+		"engagement_haip_vp_4bb0f83a_obtain_pid_sdjwt_step_006_tap_on_element_always_c.png",
+		kept[0].Filename,
+	)
+	require.Equal(
+		t,
+		"engagement_haip_vp_4bb0f83a_obtain_pid_sdjwt_credential_added_d.png",
+		kept[1].Filename,
+	)
+	require.Equal(
+		t,
+		"engagement_haip_vp_4bb0f83a_invoke_wallet_with_haip_vp_fcaf_engagement_haip_vp_invoked_e.png",
+		kept[2].Filename,
+	)
+}

--- a/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
+++ b/webapp/src/lib/pipeline/results/fcaf-report-sheet.svelte
@@ -99,7 +99,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	}
 
 	function dedupeBurstScreenshots(screenshots: Screenshot[]): Screenshot[] {
-		const burst = /^(.+)_screenshot_\d+_action_[A-Za-z0-9_]+\.yaml\d+\.png$/;
+		const burst =
+			/^(.+)(?:_screenshot_\d+_action_[A-Za-z0-9_]+\.yaml\d+|_step_\d+_[A-Za-z0-9_]+)\.png$/;
 		const lastOfBurst = new Map<string, Screenshot>();
 		for (const screenshot of screenshots) {
 			const filename = screenshot.url.split('?')[0].split('/').pop() ?? '';


### PR DESCRIPTION
## Summary

The screenshot burst dedupe from #1348 only recognized the local mobile runner's naming (`..._screenshot_<epoch>_action_<rand>.yaml<n>.png`). The cloud runner stores per-command screenshots as `<step>_step_NNN_<command_slug>.png`, so online reports repeated every intermediate shot in both the HTML sheet and the PDF.

The burst regex now recognizes both naming schemes and keeps the last shot of each burst (verified against a real credimi.io run: 31 stored screenshots dedupe to 19 — three `step_004`–`step_008` series collapse to their final shot).

## Validation

- `go test ./pkg/fcaf/...` green with a new cloud-naming dedupe test
- webapp `bun run check` 0 errors
