### PR TITLE
feat(pipeline): add web push completion notifications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ go 1.26.6
 require (
 	github.com/ForkbombEu/et-tu-cesr v0.0.0-20250730082655-1822692d6150
 	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/antchfx/htmlquery v1.3.6
 	github.com/forkbombeu/credimi-conformance-assessment v1.3.1
 	github.com/forkbombeu/credimi-extra v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsu
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1/go.mod h1:q4DKzC4UcVaAvcfd41CZh0PWpGgzrVxUYBlgKNGquUo=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
+github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
+github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -785,6 +787,7 @@ github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/pb_migrations/1788227624_created_push_subscriptions.js
+++ b/pb_migrations/1788227624_created_push_subscriptions.js
@@ -1,0 +1,96 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = new Collection({
+    "createRule": "@request.auth.id != \"\" && user = @request.auth.id",
+    "deleteRule": "user = @request.auth.id",
+    "fields": [
+      {
+        "autogeneratePattern": "[a-z0-9]{15}",
+        "hidden": false,
+        "id": "text3208210256",
+        "max": 15,
+        "min": 15,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "cascadeDelete": true,
+        "collectionId": "_pb_users_auth_",
+        "hidden": false,
+        "id": "relation3479234172",
+        "maxSelect": 1,
+        "minSelect": 0,
+        "name": "user",
+        "presentable": false,
+        "required": true,
+        "system": false,
+        "type": "relation"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text4182907513",
+        "max": 0,
+        "min": 0,
+        "name": "endpoint",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "json5213709842",
+        "maxSize": 0,
+        "name": "keys",
+        "presentable": false,
+        "required": true,
+        "system": false,
+        "type": "json"
+      },
+      {
+        "hidden": false,
+        "id": "autodate2990389176",
+        "name": "created",
+        "onCreate": true,
+        "onUpdate": false,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      },
+      {
+        "hidden": false,
+        "id": "autodate3332085495",
+        "name": "updated",
+        "onCreate": true,
+        "onUpdate": true,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      }
+    ],
+    "id": "pbc_3918024567",
+    "indexes": [
+      "CREATE UNIQUE INDEX `idx_push_subscriptions_endpoint` ON `push_subscriptions` (`endpoint`)"
+    ],
+    "listRule": "user = @request.auth.id",
+    "name": "push_subscriptions",
+    "system": false,
+    "type": "base",
+    "updateRule": "user = @request.auth.id",
+    "viewRule": "user = @request.auth.id"
+  });
+
+  return app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_3918024567");
+
+  return app.delete(collection);
+})

--- a/pb_migrations/1788227625_created_web_push_settings.js
+++ b/pb_migrations/1788227625_created_web_push_settings.js
@@ -1,0 +1,85 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = new Collection({
+    "createRule": null,
+    "deleteRule": null,
+    "fields": [
+      {
+        "autogeneratePattern": "[a-z0-9]{15}",
+        "hidden": false,
+        "id": "text3208210256",
+        "max": 15,
+        "min": 15,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text8041723591",
+        "max": 0,
+        "min": 0,
+        "name": "vapid_public_key",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text1092547683",
+        "max": 0,
+        "min": 0,
+        "name": "vapid_private_key",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "autodate2990389176",
+        "name": "created",
+        "onCreate": true,
+        "onUpdate": false,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      },
+      {
+        "hidden": false,
+        "id": "autodate3332085495",
+        "name": "updated",
+        "onCreate": true,
+        "onUpdate": true,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      }
+    ],
+    "id": "pbc_4638022411",
+    "indexes": [],
+    "listRule": null,
+    "name": "web_push_settings",
+    "system": false,
+    "type": "base",
+    "updateRule": null,
+    "viewRule": null
+  });
+
+  return app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_4638022411");
+
+  return app.delete(collection);
+})

--- a/pkg/internal/apis/RoutesRegistry.go
+++ b/pkg/internal/apis/RoutesRegistry.go
@@ -41,6 +41,7 @@ var RouteGroupsNotExported []routing.RouteGroup = []routing.RouteGroup{
 	handlers.MobileRunnerRegistrationRoutes,
 	handlers.MobileRunnerLifecycleRoutes,
 	handlers.MobileRunnersTemporalInternalRoutes,
+	handlers.WebPushRoutes,
 }
 
 func RegisterMyRoutes(app core.App) {

--- a/pkg/internal/apis/handlers/pipeline_queue_handler.go
+++ b/pkg/internal/apis/handlers/pipeline_queue_handler.go
@@ -196,8 +196,10 @@ func enqueuePipelineRun(
 		memo["metadata"] = runContext.metadata
 	}
 	config := buildPipelineQueueConfig(e, namespace, runContext.userName, runContext.userEmail)
+	// Every queue-started run notifies organization members on completion,
+	// whether it starts directly or through the runner semaphore.
+	config[pipeline.CompletionNotificationConfigKey] = true
 	applyPipelineQueueCleanupConfig(config, runContext.cleanup)
-
 	runnerInfo, err := pipeline.ParsePipelineRunnerInfo(runContext.yaml)
 	if err != nil {
 		return PipelineQueueResponse{}, apierror.New(

--- a/pkg/internal/apis/handlers/pipeline_queue_handler_test.go
+++ b/pkg/internal/apis/handlers/pipeline_queue_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/forkbombeu/credimi/pkg/internal/canonify"
 	pipelineinternal "github.com/forkbombeu/credimi/pkg/internal/pipeline"
 	"github.com/forkbombeu/credimi/pkg/workflowengine"
+	"github.com/forkbombeu/credimi/pkg/workflowengine/pipeline"
 	"github.com/forkbombeu/credimi/pkg/workflowengine/workflows"
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"
@@ -376,12 +377,14 @@ func TestPipelineQueueEnqueue_StartsNonRunnerPipeline(t *testing.T) {
 	t.Cleanup(func() {
 		startPipelineWorkflow = origStart
 	})
+	var capturedConfig map[string]any
 	startPipelineWorkflow = func(
 		yaml string,
 		config map[string]any,
 		memo map[string]any,
 		pipelineIdentifier string,
 	) (workflowengine.WorkflowResult, error) {
+		capturedConfig = config
 		return workflowengine.WorkflowResult{
 			WorkflowID:    "wf-123",
 			WorkflowRunID: "run-456",
@@ -452,6 +455,13 @@ func TestPipelineQueueEnqueue_StartsNonRunnerPipeline(t *testing.T) {
 	require.Equal(t, "wf-123", results[0].GetString("workflow_id"))
 	require.Equal(t, "run-456", results[0].GetString("run_id"))
 	require.Equal(t, pipelineinternal.RunTypeManual, results[0].GetString("type"))
+
+	require.Equal(
+		t,
+		true,
+		capturedConfig[pipeline.CompletionNotificationConfigKey],
+		"direct-start queue runs must carry the completion notification key",
+	)
 }
 
 func TestPipelineQueueStatusReturnsRunURL(t *testing.T) {

--- a/pkg/internal/apis/handlers/web_push_handlers.go
+++ b/pkg/internal/apis/handlers/web_push_handlers.go
@@ -117,17 +117,21 @@ func HandleWebPushPipelineCompleted() func(*core.RequestEvent) error {
 			duration = time.Since(startedAt.Time()).Round(time.Second).String()
 		}
 
-		sent, err := webpush.NotifyPipelineRunCompletion(e.App, webpush.CompletionRequest{
-			OrgID:        result.GetString("owner"),
-			PipelineName: pipeline.GetString("name"),
-			Organization: organization.GetString("name"),
-			WorkflowID:   input.WorkflowID,
-			RunID:        input.RunID,
-			Result:       input.Result,
-			Duration:     duration,
-			Error:        input.ErrorMessage,
-			AppURL:       appURL,
-		})
+		sent, err := webpush.NotifyPipelineRunCompletion(
+			e.Request.Context(),
+			e.App,
+			webpush.CompletionRequest{
+				OrgID:        result.GetString("owner"),
+				PipelineName: pipeline.GetString("name"),
+				Organization: organization.GetString("name"),
+				WorkflowID:   input.WorkflowID,
+				RunID:        input.RunID,
+				Result:       input.Result,
+				Duration:     duration,
+				Error:        input.ErrorMessage,
+				AppURL:       appURL,
+			},
+		)
 		if err != nil {
 			return apierror.New(
 				http.StatusInternalServerError,

--- a/pkg/internal/apis/handlers/web_push_handlers.go
+++ b/pkg/internal/apis/handlers/web_push_handlers.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/forkbombeu/credimi/pkg/internal/apierror"
+	"github.com/forkbombeu/credimi/pkg/internal/middlewares"
+	"github.com/forkbombeu/credimi/pkg/internal/routing"
+	"github.com/forkbombeu/credimi/pkg/internal/webpush"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/hook"
+)
+
+var WebPushRoutes = routing.RouteGroup{
+	BaseURL:                "/api/web-push",
+	AuthenticationRequired: false,
+	Middlewares: []*hook.Handler[*core.RequestEvent]{
+		{Func: middlewares.ErrorHandlingMiddleware},
+	},
+	Routes: []routing.RouteDefinition{
+		{
+			Method:         http.MethodGet,
+			Path:           "/vapid-public-key",
+			Handler:        HandleGetWebPushVAPIDPublicKey,
+			ResponseSchema: WebPushVAPIDPublicKeyResponse{},
+			Description:    "Get the public VAPID key used for web push subscriptions",
+		},
+		{
+			Method:         http.MethodPost,
+			Path:           "/pipeline-completed",
+			Handler:        HandleWebPushPipelineCompleted,
+			RequestSchema:  WebPushPipelineCompletedInput{},
+			ResponseSchema: WebPushPipelineCompletedResponse{},
+			Description:    "Notify organization members that a pipeline run completed",
+			Middlewares: []*hook.Handler[*core.RequestEvent]{
+				middlewares.RequireInternalAdminAPIKey(),
+			},
+		},
+	},
+}
+
+type WebPushVAPIDPublicKeyResponse struct {
+	PublicKey string `json:"public_key" validate:"required"`
+}
+
+type WebPushPipelineCompletedInput struct {
+	AppURL       string `json:"app_url"                 validate:"required"`
+	WorkflowID   string `json:"workflow_id"             validate:"required"`
+	RunID        string `json:"run_id"                  validate:"required"`
+	Result       string `json:"result"                  validate:"required"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type WebPushPipelineCompletedResponse struct {
+	Sent int `json:"sent"`
+}
+
+func HandleGetWebPushVAPIDPublicKey() func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		publicKey, _, err := webpush.GetVAPIDKeyPair(e.App)
+		if err != nil {
+			return apierror.New(
+				http.StatusInternalServerError,
+				"web_push",
+				"failed to get VAPID public key",
+				err.Error(),
+			)
+		}
+		return e.JSON(http.StatusOK, WebPushVAPIDPublicKeyResponse{PublicKey: publicKey})
+	}
+}
+
+func HandleWebPushPipelineCompleted() func(*core.RequestEvent) error {
+	return func(e *core.RequestEvent) error {
+		input, err := routing.GetValidatedInput[WebPushPipelineCompletedInput](e)
+		if err != nil {
+			return err
+		}
+
+		result, apiErr := findPipelineResultByWorkflowRun(e, input.WorkflowID, input.RunID)
+		if apiErr != nil {
+			return apiErr
+		}
+
+		pipeline, err := e.App.FindRecordById("pipelines", result.GetString("pipeline"))
+		if err != nil {
+			return apierror.New(
+				http.StatusInternalServerError,
+				"pipeline",
+				"failed to lookup pipeline",
+				err.Error(),
+			)
+		}
+
+		organization, err := e.App.FindRecordById("organizations", result.GetString("owner"))
+		if err != nil {
+			return apierror.New(
+				http.StatusInternalServerError,
+				"organization",
+				"failed to lookup organization",
+				err.Error(),
+			)
+		}
+
+		appURL := strings.TrimSpace(input.AppURL)
+		if appURL == "" {
+			appURL = e.App.Settings().Meta.AppURL
+		}
+		duration := ""
+		if startedAt := result.GetDateTime("created"); !startedAt.IsZero() {
+			duration = time.Since(startedAt.Time()).Round(time.Second).String()
+		}
+
+		sent, err := webpush.NotifyPipelineRunCompletion(e.App, webpush.CompletionRequest{
+			OrgID:        result.GetString("owner"),
+			PipelineName: pipeline.GetString("name"),
+			Organization: organization.GetString("name"),
+			WorkflowID:   input.WorkflowID,
+			RunID:        input.RunID,
+			Result:       input.Result,
+			Duration:     duration,
+			Error:        input.ErrorMessage,
+			AppURL:       appURL,
+		})
+		if err != nil {
+			return apierror.New(
+				http.StatusInternalServerError,
+				"web_push",
+				"failed to send pipeline completion notifications",
+				err.Error(),
+			)
+		}
+		return e.JSON(http.StatusOK, WebPushPipelineCompletedResponse{Sent: sent})
+	}
+}

--- a/pkg/internal/webpush/notify.go
+++ b/pkg/internal/webpush/notify.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package webpush
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	webpushgo "github.com/SherClockHolmes/webpush-go"
+	"github.com/forkbombeu/credimi/pkg/utils"
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const (
+	orgAuthorizationsCollection = "orgAuthorizations"
+	pushSubscriptionsCollection = "push_subscriptions"
+
+	// pushTTLSeconds keeps a notification deliverable for one hour so
+	// devices that are briefly offline still receive it.
+	pushTTLSeconds = 3600
+)
+
+// CompletionRequest describes a finished pipeline run to notify users about.
+type CompletionRequest struct {
+	OrgID        string
+	PipelineName string
+	Organization string
+	WorkflowID   string
+	RunID        string
+	Result       string
+	Duration     string
+	Error        string
+	AppURL       string
+}
+
+type pushPayload struct {
+	PipelineName string `json:"pipeline_name"`
+	Organization string `json:"organization,omitempty"`
+	Result       string `json:"result"`
+	Duration     string `json:"duration,omitempty"`
+	Error        string `json:"error,omitempty"`
+	URL          string `json:"url"`
+}
+
+type subscriptionKeys struct {
+	P256dh string `json:"p256dh"`
+	Auth   string `json:"auth"`
+}
+
+// NotifyPipelineRunCompletion sends a Web Push notification about a finished
+// pipeline run to every push subscription of the organization members.
+// Per-subscription failures are collected into the returned error without
+// aborting the remaining sends. Dead subscriptions (HTTP 404/410) are pruned.
+func NotifyPipelineRunCompletion(app core.App, req CompletionRequest) (int, error) {
+	publicKey, privateKey, err := GetVAPIDKeyPair(app)
+	if err != nil {
+		return 0, err
+	}
+
+	subscriptions, err := findOrgMemberSubscriptions(app, req.OrgID)
+	if err != nil {
+		return 0, err
+	}
+
+	payload, err := json.Marshal(pushPayload{
+		PipelineName: req.PipelineName,
+		Organization: req.Organization,
+		Result:       req.Result,
+		Duration:     req.Duration,
+		Error:        req.Error,
+		URL:          buildPipelineRunURL(req.AppURL, req.WorkflowID, req.RunID),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal push payload: %w", err)
+	}
+
+	sent := 0
+	var sendErrs []error
+
+	for _, subscription := range subscriptions {
+		delivered, err := sendPush(
+			context.Background(),
+			app,
+			subscription,
+			payload,
+			publicKey,
+			privateKey,
+			req.AppURL,
+		)
+		if err != nil {
+			sendErrs = append(sendErrs, err)
+			continue
+		}
+		if delivered {
+			sent++
+		}
+	}
+	return sent, errors.Join(sendErrs...)
+}
+
+func buildPipelineRunURL(appURL string, workflowID string, runID string) string {
+	return utils.JoinURL(appURL, "my", "tests", "runs", workflowID, runID)
+}
+
+func findOrgMemberSubscriptions(app core.App, orgID string) ([]*core.Record, error) {
+	members, err := app.FindRecordsByFilter(
+		orgAuthorizationsCollection,
+		"organization = {:org}",
+		"",
+		0,
+		0,
+		dbx.Params{"org": orgID},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve organization members: %w", err)
+	}
+
+	var subscriptions []*core.Record
+	for _, member := range members {
+		userID := member.GetString("user")
+		if userID == "" {
+			continue
+		}
+		userSubscriptions, err := app.FindRecordsByFilter(
+			pushSubscriptionsCollection,
+			"user = {:user}",
+			"",
+			0,
+			0,
+			dbx.Params{"user": userID},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch push subscriptions: %w", err)
+		}
+		subscriptions = append(subscriptions, userSubscriptions...)
+	}
+	return subscriptions, nil
+}
+
+func sendPush(
+	ctx context.Context,
+	app core.App,
+	record *core.Record,
+	payload []byte,
+	publicKey string,
+	privateKey string,
+	appURL string,
+) (bool, error) {
+	var keys subscriptionKeys
+	if err := record.UnmarshalJSONField("keys", &keys); err != nil {
+		return false, fmt.Errorf("invalid push subscription keys: %w", err)
+	}
+
+	subscription := webpushgo.Subscription{
+		Endpoint: record.GetString("endpoint"),
+		Keys: webpushgo.Keys{
+			P256dh: keys.P256dh,
+			Auth:   keys.Auth,
+		},
+	}
+	resp, err := webpushgo.SendNotificationWithContext(
+		ctx,
+		payload,
+		&subscription,
+		&webpushgo.Options{
+			Subscriber:      appURL,
+			TTL:             pushTTLSeconds,
+			VAPIDPublicKey:  publicKey,
+			VAPIDPrivateKey: privateKey,
+		},
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to send push notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return true, nil
+	case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+		if err := app.Delete(record); err != nil {
+			return false, fmt.Errorf("failed to prune dead push subscription: %w", err)
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("push service returned status: %s", resp.Status)
+	}
+}

--- a/pkg/internal/webpush/notify.go
+++ b/pkg/internal/webpush/notify.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	webpushgo "github.com/SherClockHolmes/webpush-go"
 	"github.com/forkbombeu/credimi/pkg/utils"
@@ -24,6 +26,10 @@ const (
 	// pushTTLSeconds keeps a notification deliverable for one hour so
 	// devices that are briefly offline still receive it.
 	pushTTLSeconds = 3600
+
+	// pushSendTimeout bounds a single push send so a stalled push service
+	// cannot hang the whole notification fan-out.
+	pushSendTimeout = 10 * time.Second
 )
 
 // CompletionRequest describes a finished pipeline run to notify users about.
@@ -57,7 +63,11 @@ type subscriptionKeys struct {
 // pipeline run to every push subscription of the organization members.
 // Per-subscription failures are collected into the returned error without
 // aborting the remaining sends. Dead subscriptions (HTTP 404/410) are pruned.
-func NotifyPipelineRunCompletion(app core.App, req CompletionRequest) (int, error) {
+func NotifyPipelineRunCompletion(
+	ctx context.Context,
+	app core.App,
+	req CompletionRequest,
+) (int, error) {
 	publicKey, privateKey, err := GetVAPIDKeyPair(app)
 	if err != nil {
 		return 0, err
@@ -82,10 +92,10 @@ func NotifyPipelineRunCompletion(app core.App, req CompletionRequest) (int, erro
 
 	sent := 0
 	var sendErrs []error
-
 	for _, subscription := range subscriptions {
+		sendCtx, cancel := context.WithTimeout(ctx, pushSendTimeout)
 		delivered, err := sendPush(
-			context.Background(),
+			sendCtx,
 			app,
 			subscription,
 			payload,
@@ -93,6 +103,7 @@ func NotifyPipelineRunCompletion(app core.App, req CompletionRequest) (int, erro
 			privateKey,
 			req.AppURL,
 		)
+		cancel()
 		if err != nil {
 			sendErrs = append(sendErrs, err)
 			continue
@@ -121,24 +132,31 @@ func findOrgMemberSubscriptions(app core.App, orgID string) ([]*core.Record, err
 		return nil, fmt.Errorf("failed to resolve organization members: %w", err)
 	}
 
-	var subscriptions []*core.Record
-	for _, member := range members {
+	params := dbx.Params{"org": orgID}
+	conditions := make([]string, 0, len(members))
+	for i, member := range members {
 		userID := member.GetString("user")
 		if userID == "" {
 			continue
 		}
-		userSubscriptions, err := app.FindRecordsByFilter(
-			pushSubscriptionsCollection,
-			"user = {:user}",
-			"",
-			0,
-			0,
-			dbx.Params{"user": userID},
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch push subscriptions: %w", err)
-		}
-		subscriptions = append(subscriptions, userSubscriptions...)
+		key := fmt.Sprintf("user%d", i)
+		params[key] = userID
+		conditions = append(conditions, fmt.Sprintf("user = {:%s}", key))
+	}
+	if len(conditions) == 0 {
+		return nil, nil
+	}
+
+	subscriptions, err := app.FindRecordsByFilter(
+		pushSubscriptionsCollection,
+		strings.Join(conditions, " || "),
+		"",
+		0,
+		0,
+		params,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch push subscriptions: %w", err)
 	}
 	return subscriptions, nil
 }

--- a/pkg/internal/webpush/vapid.go
+++ b/pkg/internal/webpush/vapid.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package webpush
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	webpushgo "github.com/SherClockHolmes/webpush-go"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const (
+	// EnvVAPIDPublicKey overrides the stored VAPID public key.
+	EnvVAPIDPublicKey = "CREDIMI_WEB_PUSH_VAPID_PUBLIC_KEY"
+	// EnvVAPIDPrivateKey overrides the stored VAPID private key.
+	EnvVAPIDPrivateKey = "CREDIMI_WEB_PUSH_VAPID_PRIVATE_KEY"
+
+	webPushSettingsCollection = "web_push_settings"
+)
+
+// GetVAPIDKeyPair returns the Web Push VAPID key pair, generating and
+// persisting a new one on first use. When both environment variables are set
+// they take precedence over the stored key pair.
+func GetVAPIDKeyPair(app core.App) (publicKey string, privateKey string, err error) {
+	envPublicKey := strings.TrimSpace(os.Getenv(EnvVAPIDPublicKey))
+	envPrivateKey := strings.TrimSpace(os.Getenv(EnvVAPIDPrivateKey))
+	switch {
+	case envPublicKey != "" && envPrivateKey != "":
+		return envPublicKey, envPrivateKey, nil
+	case envPublicKey != "" || envPrivateKey != "":
+		return "", "", fmt.Errorf(
+			"%s and %s must both be set",
+			EnvVAPIDPublicKey,
+			EnvVAPIDPrivateKey,
+		)
+	}
+
+	record, err := app.FindFirstRecordByFilter(webPushSettingsCollection, "")
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return "", "", fmt.Errorf("failed to load web push settings: %w", err)
+		}
+
+		generatedPrivateKey, generatedPublicKey, err := webpushgo.GenerateVAPIDKeys()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to generate VAPID keys: %w", err)
+		}
+		if err := saveVAPIDKeyPair(app, generatedPublicKey, generatedPrivateKey); err != nil {
+			return "", "", err
+		}
+		return generatedPublicKey, generatedPrivateKey, nil
+	}
+
+	publicKey = record.GetString("vapid_public_key")
+	privateKey = record.GetString("vapid_private_key")
+	if publicKey == "" || privateKey == "" {
+		return "", "", fmt.Errorf("stored VAPID key pair is incomplete")
+	}
+	return publicKey, privateKey, nil
+}
+
+func saveVAPIDKeyPair(app core.App, publicKey string, privateKey string) error {
+	collection, err := app.FindCollectionByNameOrId(webPushSettingsCollection)
+	if err != nil {
+		return fmt.Errorf("failed to get web push settings collection: %w", err)
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("vapid_public_key", publicKey)
+	record.Set("vapid_private_key", privateKey)
+	if err := app.Save(record); err != nil {
+		return fmt.Errorf("failed to store VAPID key pair: %w", err)
+	}
+	return nil
+}

--- a/pkg/internal/webpush/webpush_test.go
+++ b/pkg/internal/webpush/webpush_test.go
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package webpush
+
+import (
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/require"
+)
+
+const testDataDir = "../../../test_pb_data"
+
+func setupWebPushApp(t testing.TB) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp(testDataDir)
+	require.NoError(t, err)
+
+	subscriptions := core.NewCollection(core.CollectionTypeBase, pushSubscriptionsCollection)
+	subscriptions.Fields.Add(
+		&core.RelationField{
+			Name:          "user",
+			CollectionId:  "_pb_users_auth_",
+			MaxSelect:     1,
+			CascadeDelete: true,
+			Required:      true,
+		},
+		&core.TextField{Name: "endpoint", Required: true},
+		&core.JSONField{Name: "keys", Required: true},
+	)
+	require.NoError(t, app.Save(subscriptions))
+
+	settings := core.NewCollection(core.CollectionTypeBase, webPushSettingsCollection)
+	settings.Fields.Add(
+		&core.TextField{Name: "vapid_public_key", Required: true},
+		&core.TextField{Name: "vapid_private_key", Required: true},
+	)
+	require.NoError(t, app.Save(settings))
+
+	return app
+}
+func firstOrgMember(t testing.TB, app *tests.TestApp) (orgID string, userID string) {
+	t.Helper()
+
+	authorization, err := app.FindFirstRecordByFilter(orgAuthorizationsCollection, "")
+	require.NoError(t, err)
+
+	return authorization.GetString("organization"), authorization.GetString("user")
+}
+
+func firstNonMemberUser(t testing.TB, app *tests.TestApp, memberUserID string) string {
+	t.Helper()
+
+	user, err := app.FindFirstRecordByFilter(
+		"users",
+		"id != {:id}",
+		dbx.Params{"id": memberUserID},
+	)
+	require.NoError(t, err)
+
+	return user.Id
+}
+
+func createPushSubscription(
+	t testing.TB,
+	app *tests.TestApp,
+	userID string,
+	endpoint string,
+) *core.Record {
+	t.Helper()
+
+	private, x, y, err := elliptic.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	require.NotEmpty(t, private)
+
+	collection, err := app.FindCollectionByNameOrId(pushSubscriptionsCollection)
+	require.NoError(t, err)
+
+	record := core.NewRecord(collection)
+	record.Set("user", userID)
+	record.Set("endpoint", endpoint)
+	record.Set("keys", map[string]any{
+		"p256dh": base64.RawURLEncoding.EncodeToString(elliptic.Marshal(elliptic.P256(), x, y)),
+		"auth":   base64.RawURLEncoding.EncodeToString([]byte("test-auth-16byte")),
+	})
+	require.NoError(t, app.Save(record))
+	return record
+}
+
+func TestGetVAPIDKeyPairGeneratesAndPersists(t *testing.T) {
+	app := setupWebPushApp(t)
+	defer app.Cleanup()
+
+	t.Setenv(EnvVAPIDPublicKey, "")
+	t.Setenv(EnvVAPIDPrivateKey, "")
+
+	publicKey, privateKey, err := GetVAPIDKeyPair(app)
+	require.NoError(t, err)
+	require.NotEmpty(t, publicKey)
+	require.NotEmpty(t, privateKey)
+
+	secondPublicKey, secondPrivateKey, err := GetVAPIDKeyPair(app)
+	require.NoError(t, err)
+	require.Equal(t, publicKey, secondPublicKey)
+	require.Equal(t, privateKey, secondPrivateKey)
+
+	total, err := app.CountRecords(webPushSettingsCollection)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+}
+
+func TestGetVAPIDKeyPairEnvOverride(t *testing.T) {
+	app := setupWebPushApp(t)
+	defer app.Cleanup()
+
+	t.Setenv(EnvVAPIDPublicKey, "env-public-key")
+	t.Setenv(EnvVAPIDPrivateKey, "env-private-key")
+
+	publicKey, privateKey, err := GetVAPIDKeyPair(app)
+	require.NoError(t, err)
+	require.Equal(t, "env-public-key", publicKey)
+	require.Equal(t, "env-private-key", privateKey)
+
+	total, err := app.CountRecords(webPushSettingsCollection)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), total)
+}
+
+func TestGetVAPIDKeyPairEnvPartialOverrideError(t *testing.T) {
+	app := setupWebPushApp(t)
+	defer app.Cleanup()
+
+	t.Setenv(EnvVAPIDPublicKey, "env-public-key")
+	t.Setenv(EnvVAPIDPrivateKey, "")
+
+	_, _, err := GetVAPIDKeyPair(app)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must both be set")
+}
+
+func TestBuildPipelineRunURL(t *testing.T) {
+	require.Equal(
+		t,
+		"https://credimi.test/my/tests/runs/wf-1/run-1",
+		buildPipelineRunURL("https://credimi.test", "wf-1", "run-1"),
+	)
+}
+
+func TestNotifyPipelineRunCompletionSendsToOrgMembersOnly(t *testing.T) {
+	app := setupWebPushApp(t)
+	defer app.Cleanup()
+
+	t.Setenv(EnvVAPIDPublicKey, "")
+	t.Setenv(EnvVAPIDPrivateKey, "")
+
+	orgID, memberUserID := firstOrgMember(t, app)
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	// The non-member user has no authorization for the organization.
+	createPushSubscription(t, app, memberUserID, server.URL)
+	createPushSubscription(t, app, firstNonMemberUser(t, app, memberUserID), server.URL)
+
+	sent, err := NotifyPipelineRunCompletion(app, CompletionRequest{
+		OrgID:        orgID,
+		PipelineName: "my-pipeline",
+		WorkflowID:   "wf-1",
+		RunID:        "run-1",
+		Result:       "success",
+		AppURL:       "https://credimi.test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, sent)
+	require.Equal(t, int32(1), requests.Load())
+}
+
+func TestNotifyPipelineRunCompletionPrunesDeadSubscriptions(t *testing.T) {
+	app := setupWebPushApp(t)
+	defer app.Cleanup()
+
+	t.Setenv(EnvVAPIDPublicKey, "")
+	t.Setenv(EnvVAPIDPrivateKey, "")
+
+	orgID, userID := firstOrgMember(t, app)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	}))
+	defer server.Close()
+
+	subscription := createPushSubscription(t, app, userID, server.URL)
+
+	sent, err := NotifyPipelineRunCompletion(app, CompletionRequest{
+		OrgID:        orgID,
+		PipelineName: "my-pipeline",
+		WorkflowID:   "wf-1",
+		RunID:        "run-1",
+		Result:       "failed",
+		AppURL:       "https://credimi.test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, sent)
+
+	_, err = app.FindRecordById(pushSubscriptionsCollection, subscription.Id)
+	require.Error(t, err)
+}
+
+func TestNotifyPipelineRunCompletionCollectsFailures(t *testing.T) {
+	app := setupWebPushApp(t)
+	defer app.Cleanup()
+
+	t.Setenv(EnvVAPIDPublicKey, "")
+	t.Setenv(EnvVAPIDPrivateKey, "")
+
+	orgID, userID := firstOrgMember(t, app)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	subscription := createPushSubscription(t, app, userID, server.URL)
+
+	sent, err := NotifyPipelineRunCompletion(app, CompletionRequest{
+		OrgID:        orgID,
+		PipelineName: "my-pipeline",
+		WorkflowID:   "wf-1",
+		RunID:        "run-1",
+		Result:       "failed",
+		AppURL:       "https://credimi.test",
+	})
+	require.Error(t, err)
+	require.Equal(t, 0, sent)
+	require.Contains(t, err.Error(), "push service returned status: 500")
+
+	_, err = app.FindRecordById(pushSubscriptionsCollection, subscription.Id)
+	require.NoError(t, err)
+}

--- a/pkg/internal/webpush/webpush_test.go
+++ b/pkg/internal/webpush/webpush_test.go
@@ -5,6 +5,7 @@
 package webpush
 
 import (
+	"context"
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
@@ -177,7 +178,7 @@ func TestNotifyPipelineRunCompletionSendsToOrgMembersOnly(t *testing.T) {
 	createPushSubscription(t, app, memberUserID, server.URL)
 	createPushSubscription(t, app, firstNonMemberUser(t, app, memberUserID), server.URL)
 
-	sent, err := NotifyPipelineRunCompletion(app, CompletionRequest{
+	sent, err := NotifyPipelineRunCompletion(context.Background(), app, CompletionRequest{
 		OrgID:        orgID,
 		PipelineName: "my-pipeline",
 		WorkflowID:   "wf-1",
@@ -206,7 +207,7 @@ func TestNotifyPipelineRunCompletionPrunesDeadSubscriptions(t *testing.T) {
 
 	subscription := createPushSubscription(t, app, userID, server.URL)
 
-	sent, err := NotifyPipelineRunCompletion(app, CompletionRequest{
+	sent, err := NotifyPipelineRunCompletion(context.Background(), app, CompletionRequest{
 		OrgID:        orgID,
 		PipelineName: "my-pipeline",
 		WorkflowID:   "wf-1",
@@ -237,7 +238,7 @@ func TestNotifyPipelineRunCompletionCollectsFailures(t *testing.T) {
 
 	subscription := createPushSubscription(t, app, userID, server.URL)
 
-	sent, err := NotifyPipelineRunCompletion(app, CompletionRequest{
+	sent, err := NotifyPipelineRunCompletion(context.Background(), app, CompletionRequest{
 		OrgID:        orgID,
 		PipelineName: "my-pipeline",
 		WorkflowID:   "wf-1",

--- a/pkg/workflowengine/activities/pipeline_completion_notification.go
+++ b/pkg/workflowengine/activities/pipeline_completion_notification.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package activities
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/forkbombeu/credimi/pkg/internal/errorcodes"
+	"github.com/forkbombeu/credimi/pkg/utils"
+	"github.com/forkbombeu/credimi/pkg/workflowengine"
+)
+
+type SendPipelineCompletionNotificationInput struct {
+	AppURL       string `json:"app_url"`
+	WorkflowID   string `json:"workflow_id"`
+	RunID        string `json:"run_id"`
+	Result       string `json:"result"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+type SendPipelineCompletionNotificationActivity struct {
+	workflowengine.BaseActivity
+}
+
+func NewSendPipelineCompletionNotificationActivity() *SendPipelineCompletionNotificationActivity {
+	return &SendPipelineCompletionNotificationActivity{
+		BaseActivity: workflowengine.BaseActivity{
+			Name: "Send pipeline completion notification",
+		},
+	}
+}
+
+func (a *SendPipelineCompletionNotificationActivity) Name() string {
+	return a.BaseActivity.Name
+}
+
+func (a *SendPipelineCompletionNotificationActivity) Execute(
+	ctx context.Context,
+	input workflowengine.ActivityInput,
+) (workflowengine.ActivityResult, error) {
+	var result workflowengine.ActivityResult
+	payload, err := workflowengine.DecodePayload[SendPipelineCompletionNotificationInput](
+		input.Payload,
+	)
+	if err != nil {
+		return result, a.NewMissingOrInvalidPayloadError(err)
+	}
+
+	appURL := strings.TrimSpace(payload.AppURL)
+	workflowID := strings.TrimSpace(payload.WorkflowID)
+	runID := strings.TrimSpace(payload.RunID)
+	if appURL == "" || workflowID == "" || runID == "" {
+		errCode := errorcodes.Codes[errorcodes.MissingOrInvalidPayload]
+		return result, a.NewActivityError(workflowengine.ActivityError{
+			Code:    errCode.Code,
+			Summary: errCode.Description,
+			Message: "app_url, workflow_id, and run_id are required",
+		})
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv("CREDIMI_INTERNAL_ADMIN_KEY"))
+	if apiKey == "" {
+		errCode := errorcodes.Codes[errorcodes.MissingOrInvalidConfig]
+		return result, a.NewActivityError(workflowengine.ActivityError{
+			Code:    errCode.Code,
+			Summary: errCode.Description,
+			Message: "CREDIMI_INTERNAL_ADMIN_KEY is required",
+		})
+	}
+
+	body, err := json.Marshal(SendPipelineCompletionNotificationInput{
+		AppURL:       appURL,
+		WorkflowID:   workflowID,
+		RunID:        runID,
+		Result:       strings.TrimSpace(payload.Result),
+		ErrorMessage: strings.TrimSpace(payload.ErrorMessage),
+	})
+	if err != nil {
+		return result, fmt.Errorf("marshal pipeline completion notification payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		utils.JoinURL(appURL, "api", "web-push", "pipeline-completed"),
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return result, fmt.Errorf("build pipeline completion notification request: %w", err)
+	}
+	req.Header.Set(workflowengine.HTTPHeaderContentType, workflowengine.MIMEApplicationJSON)
+	req.Header.Set("Credimi-Api-Key", apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return result, fmt.Errorf("post pipeline completion notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return result, fmt.Errorf(
+			"pipeline completion notification status: %s",
+			resp.Status,
+		)
+	}
+	return result, nil
+}

--- a/pkg/workflowengine/activities/pipeline_completion_notification_test.go
+++ b/pkg/workflowengine/activities/pipeline_completion_notification_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package activities
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/forkbombeu/credimi/pkg/internal/errorcodes"
+	"github.com/forkbombeu/credimi/pkg/workflowengine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendPipelineCompletionNotificationActivityName(t *testing.T) {
+	require.Equal(
+		t,
+		"Send pipeline completion notification",
+		NewSendPipelineCompletionNotificationActivity().Name(),
+	)
+}
+
+func TestSendPipelineCompletionNotificationActivitySuccess(t *testing.T) {
+	var mu sync.Mutex
+	var gotPath, gotAPIKey, gotContentType, gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		defer mu.Unlock()
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("Credimi-Api-Key")
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("CREDIMI_INTERNAL_ADMIN_KEY", "internal-admin-key")
+
+	activity := NewSendPipelineCompletionNotificationActivity()
+	_, err := activity.Execute(context.Background(), workflowengine.ActivityInput{
+		Payload: SendPipelineCompletionNotificationInput{
+			AppURL:     server.URL,
+			WorkflowID: "wf-1",
+			RunID:      "run-1",
+			Result:     "success",
+		},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "/api/web-push/pipeline-completed", gotPath)
+	require.Equal(t, "internal-admin-key", gotAPIKey)
+	require.Equal(t, workflowengine.MIMEApplicationJSON, gotContentType)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal([]byte(gotBody), &body))
+	require.Equal(t, server.URL, body["app_url"])
+	require.Equal(t, "wf-1", body["workflow_id"])
+	require.Equal(t, "run-1", body["run_id"])
+	require.Equal(t, "success", body["result"])
+}
+
+func TestSendPipelineCompletionNotificationActivityMissingFields(t *testing.T) {
+	t.Setenv("CREDIMI_INTERNAL_ADMIN_KEY", "internal-admin-key")
+
+	activity := NewSendPipelineCompletionNotificationActivity()
+	_, err := activity.Execute(context.Background(), workflowengine.ActivityInput{
+		Payload: SendPipelineCompletionNotificationInput{
+			WorkflowID: "wf-1",
+			RunID:      "run-1",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errorcodes.Codes[errorcodes.MissingOrInvalidPayload].Code)
+}
+
+func TestSendPipelineCompletionNotificationActivityMissingAdminKey(t *testing.T) {
+	t.Setenv("CREDIMI_INTERNAL_ADMIN_KEY", "")
+
+	activity := NewSendPipelineCompletionNotificationActivity()
+	_, err := activity.Execute(context.Background(), workflowengine.ActivityInput{
+		Payload: SendPipelineCompletionNotificationInput{
+			AppURL:     "http://127.0.0.1:1",
+			WorkflowID: "wf-1",
+			RunID:      "run-1",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CREDIMI_INTERNAL_ADMIN_KEY is required")
+}
+
+func TestSendPipelineCompletionNotificationActivityNonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	t.Setenv("CREDIMI_INTERNAL_ADMIN_KEY", "internal-admin-key")
+
+	activity := NewSendPipelineCompletionNotificationActivity()
+	_, err := activity.Execute(context.Background(), workflowengine.ActivityInput{
+		Payload: SendPipelineCompletionNotificationInput{
+			AppURL:     server.URL,
+			WorkflowID: "wf-1",
+			RunID:      "run-1",
+			Result:     "failed",
+		},
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "pipeline completion notification status"))
+}

--- a/pkg/workflowengine/activities/queued_pipeline.go
+++ b/pkg/workflowengine/activities/queued_pipeline.go
@@ -54,17 +54,16 @@ type StartQueuedPipelineActivityOutput struct {
 }
 
 const (
-	pipelineTaskQueue              = "PipelineTaskQueue"
-	pipelineWorkflowName           = "Dynamic Pipeline Workflow"
-	defaultExecutionTimeout        = "24h"
-	defaultActivityScheduleTimeout = "10m"
-	defaultActivityStartTimeout    = "5m"
-	defaultActivityHeartbeat       = "30s"
-	defaultRetryMaxAttempts        = int32(5)
-	defaultRetryInitialInterval    = "5s"
-	defaultRetryMaxInterval        = "1m"
-	defaultRetryBackoffCoefficient = 2.0
-
+	pipelineTaskQueue                            = "PipelineTaskQueue"
+	pipelineWorkflowName                         = "Dynamic Pipeline Workflow"
+	defaultExecutionTimeout                      = "24h"
+	defaultActivityScheduleTimeout               = "10m"
+	defaultActivityStartTimeout                  = "5m"
+	defaultActivityHeartbeat                     = "30s"
+	defaultRetryMaxAttempts                      = int32(5)
+	defaultRetryInitialInterval                  = "5s"
+	defaultRetryMaxInterval                      = "1m"
+	defaultRetryBackoffCoefficient               = 2.0
 	mobileRunnerSemaphoreTicketIDConfigKey       = "mobile_runner_semaphore_ticket_id"
 	mobileRunnerSemaphoreRunnerIDsConfigKey      = "mobile_runner_semaphore_runner_ids"
 	mobileRunnerSemaphoreLeaderRunnerIDConfigKey = "mobile_runner_semaphore_leader_runner_id"

--- a/pkg/workflowengine/pipeline/completion_notification.go
+++ b/pkg/workflowengine/pipeline/completion_notification.go
@@ -65,6 +65,17 @@ func reportPipelineCompletionNotification(
 	}
 }
 
+// truncateWorkflowError caps a notification body by rune count so multi-byte
+// characters are never split mid-rune.
+func truncateWorkflowError(message string) string {
+	const maxLength = 140
+	runes := []rune(message)
+	if len(runes) <= maxLength {
+		return message
+	}
+	return string(runes[:maxLength]) + "…"
+}
+
 // workflowErrorMessage derives a short, notification-sized cause from the
 // workflow error. Empty for canceled runs and plain Temporal errors.
 func workflowErrorMessage(err error) string {
@@ -82,12 +93,4 @@ func workflowErrorMessage(err error) string {
 		return truncateWorkflowError(wfErr.Code)
 	}
 	return truncateWorkflowError(wfErr.Code + ": " + wfErr.Summary)
-}
-
-func truncateWorkflowError(message string) string {
-	const maxLength = 140
-	if len(message) <= maxLength {
-		return message
-	}
-	return message[:maxLength] + "…"
 }

--- a/pkg/workflowengine/pipeline/completion_notification.go
+++ b/pkg/workflowengine/pipeline/completion_notification.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"github.com/forkbombeu/credimi/pkg/workflowengine"
+	"github.com/forkbombeu/credimi/pkg/workflowengine/activities"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+)
+
+// CompletionNotificationConfigKey marks queued runs that should send a web
+// push notification when they reach a terminal state. The queue handler
+// injects it for every run it starts, directly or through the semaphore.
+const CompletionNotificationConfigKey = "pipeline_completion_notification"
+
+func reportPipelineCompletionNotification(
+	ctx workflow.Context,
+	logger log.Logger,
+	config map[string]any,
+	workflowID string,
+	runID string,
+	workflowResult string,
+	workflowErr error,
+) {
+	if config == nil {
+		return
+	}
+
+	// The queue start path injects this key when it also creates the
+	// pipeline_results record the notification handler resolves.
+	if enabled, _ := config[CompletionNotificationConfigKey].(bool); !enabled {
+		return
+	}
+	appURL, _ := config["app_url"].(string)
+	if appURL == "" {
+		return
+	}
+
+	notificationActivity := activities.NewSendPipelineCompletionNotificationActivity()
+	payload := activities.SendPipelineCompletionNotificationInput{
+		AppURL:       appURL,
+		WorkflowID:   workflowID,
+		RunID:        runID,
+		Result:       workflowResult,
+		ErrorMessage: workflowErrorMessage(workflowErr),
+	}
+
+	if err := workflow.ExecuteActivity(
+		ctx,
+		notificationActivity.Name(),
+		workflowengine.ActivityInput{Payload: payload},
+	).Get(ctx, nil); err != nil {
+		logger.Error(
+			"failed to send pipeline completion notification",
+			"workflow_id",
+			workflowID,
+			"run_id",
+			runID,
+			"error",
+			err,
+		)
+	}
+}
+
+// workflowErrorMessage derives a short, notification-sized cause from the
+// workflow error. Empty for canceled runs and plain Temporal errors.
+func workflowErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	wfErr := workflowengine.ParseWorkflowError(err)
+	if wfErr.Code == "" && wfErr.Summary == "" {
+		return ""
+	}
+	if wfErr.Code == "" {
+		return truncateWorkflowError(wfErr.Summary)
+	}
+	if wfErr.Summary == "" {
+		return truncateWorkflowError(wfErr.Code)
+	}
+	return truncateWorkflowError(wfErr.Code + ": " + wfErr.Summary)
+}
+
+func truncateWorkflowError(message string) string {
+	const maxLength = 140
+	if len(message) <= maxLength {
+		return message
+	}
+	return message[:maxLength] + "…"
+}

--- a/pkg/workflowengine/pipeline/completion_notification_test.go
+++ b/pkg/workflowengine/pipeline/completion_notification_test.go
@@ -5,8 +5,10 @@
 package pipeline
 
 import (
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/forkbombeu/credimi/pkg/internal/pipeline"
 	"github.com/forkbombeu/credimi/pkg/workflowengine"
@@ -131,4 +133,16 @@ func TestPipelineSkipsCompletionNotificationWithoutConfigKey(t *testing.T) {
 	})
 
 	require.NoError(t, env.GetWorkflowError())
+}
+
+func TestTruncateWorkflowErrorKeepsRunesIntact(t *testing.T) {
+	t.Parallel()
+
+	// 100 "€" runes = 300 bytes, plus a suffix that pushes past the limit.
+	long := strings.Repeat("€", 100) + "trailing text beyond the limit"
+	got := truncateWorkflowError(long)
+
+	require.LessOrEqual(t, len([]rune(got)), 141)
+	require.True(t, utf8.ValidString(got), "truncated message must stay valid UTF-8")
+	require.Contains(t, got, "€")
 }

--- a/pkg/workflowengine/pipeline/completion_notification_test.go
+++ b/pkg/workflowengine/pipeline/completion_notification_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/forkbombeu/credimi/pkg/internal/pipeline"
+	"github.com/forkbombeu/credimi/pkg/workflowengine"
+	"github.com/forkbombeu/credimi/pkg/workflowengine/activities"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+)
+
+func TestPipelineReportsCompletionNotification(t *testing.T) {
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	pipelineWf := NewPipelineWorkflow()
+	env.RegisterWorkflowWithOptions(
+		pipelineWf.Workflow,
+		workflow.RegisterOptions{Name: pipelineWf.Name()},
+	)
+
+	notificationActivity := activities.NewSendPipelineCompletionNotificationActivity()
+	env.RegisterActivityWithOptions(
+		notificationActivity.Execute,
+		activity.RegisterOptions{Name: notificationActivity.Name()},
+	)
+
+	originalSetupHooks := setupHooks
+	originalCleanupHooks := cleanupHooks
+	setupHooks = []SetupFunc{}
+	cleanupHooks = []CleanupFunc{}
+	t.Cleanup(func() {
+		setupHooks = originalSetupHooks
+		cleanupHooks = originalCleanupHooks
+	})
+
+	var notified bool
+	env.OnActivity(
+		notificationActivity.Name(),
+		mock.Anything,
+		mock.MatchedBy(func(input workflowengine.ActivityInput) bool {
+			payload, ok := input.Payload.(activities.SendPipelineCompletionNotificationInput)
+			if !ok {
+				decoded, err := workflowengine.
+					DecodePayload[activities.SendPipelineCompletionNotificationInput](
+					input.Payload,
+				)
+				if err != nil {
+					return false
+				}
+				payload = decoded
+			}
+			return payload.AppURL == "https://example.test" &&
+				payload.WorkflowID == "default-test-workflow-id" &&
+				payload.RunID == "default-test-run-id" &&
+				payload.Result == resultSuccess
+		}),
+	).
+		Run(func(_ mock.Arguments) {
+			notified = true
+		}).
+		Return(workflowengine.ActivityResult{}, nil).
+		Once()
+
+	env.ExecuteWorkflow(pipelineWf.Name(), PipelineWorkflowInput{
+		WorkflowDefinition: &pipeline.WorkflowDefinition{
+			Name:  "test-pipeline",
+			Steps: []pipeline.StepDefinition{},
+		},
+		WorkflowInput: workflowengine.WorkflowInput{
+			Config: map[string]any{
+				"app_url":                          "https://example.test",
+				"pipeline_completion_notification": true,
+			},
+			ActivityOptions: &workflow.ActivityOptions{StartToCloseTimeout: time.Second},
+		},
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, notified, "completion notification activity should have been invoked")
+	env.AssertExpectations(t)
+}
+
+func TestPipelineSkipsCompletionNotificationWithoutConfigKey(t *testing.T) {
+	suite := testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
+
+	pipelineWf := NewPipelineWorkflow()
+	env.RegisterWorkflowWithOptions(
+		pipelineWf.Workflow,
+		workflow.RegisterOptions{Name: pipelineWf.Name()},
+	)
+
+	notificationActivity := activities.NewSendPipelineCompletionNotificationActivity()
+	env.RegisterActivityWithOptions(
+		notificationActivity.Execute,
+		activity.RegisterOptions{Name: notificationActivity.Name()},
+	)
+
+	originalSetupHooks := setupHooks
+	originalCleanupHooks := cleanupHooks
+	setupHooks = []SetupFunc{}
+	cleanupHooks = []CleanupFunc{}
+	t.Cleanup(func() {
+		setupHooks = originalSetupHooks
+		cleanupHooks = originalCleanupHooks
+	})
+
+	// No OnActivity mock: any invocation of the notification activity would
+	// panic the test environment, which is exactly the failure we want caught.
+	env.ExecuteWorkflow(pipelineWf.Name(), PipelineWorkflowInput{
+		WorkflowDefinition: &pipeline.WorkflowDefinition{
+			Name:  "test-pipeline",
+			Steps: []pipeline.StepDefinition{},
+		},
+		WorkflowInput: workflowengine.WorkflowInput{
+			Config: map[string]any{
+				"app_url": "https://example.test",
+			},
+			ActivityOptions: &workflow.ActivityOptions{StartToCloseTimeout: time.Second},
+		},
+	})
+
+	require.NoError(t, env.GetWorkflowError())
+}

--- a/pkg/workflowengine/pipeline/pipeline.go
+++ b/pkg/workflowengine/pipeline/pipeline.go
@@ -126,6 +126,15 @@ func (w *PipelineWorkflow) Workflow(
 			runID,
 			finalResult,
 		)
+		reportPipelineCompletionNotification(
+			ctx,
+			logger,
+			config,
+			workflowID,
+			runID,
+			finalResult,
+			finalErr,
+		)
 	}()
 
 	if wfDef == nil {

--- a/pkg/workflowengine/registry/registry.go
+++ b/pkg/workflowengine/registry/registry.go
@@ -182,4 +182,10 @@ var PipelineInternalRegistry = map[string]TaskFactory{
 		PayloadType: reflect.TypeOf(activities.PipelineReportGenerationInput{}),
 		OutputKind:  workflowengine.OutputMap,
 	},
+	"pipeline-completion-notification": {
+		Kind:        TaskActivity,
+		NewFunc:     func() any { return activities.NewSendPipelineCompletionNotificationActivity() },
+		PayloadType: reflect.TypeOf(activities.SendPipelineCompletionNotificationInput{}),
+		OutputKind:  workflowengine.OutputAny,
+	},
 }

--- a/webapp/messages/da.json
+++ b/webapp/messages/da.json
@@ -1016,5 +1016,13 @@
 	"extra_eudi_atlas": "EUDI Atlas",
 	"extra_eudi_atlas_description": "Omfattende EUDI-dokumentkort (organiseret efter rolle) med konformitetstestguide",
 	"extra_tl_lote_onboarding_catalogue": "TL/LoTE-onboarding/-katalog",
-	"extra_tl_lote_onboarding_catalogue_description": "Onboard EUDI-komponenter på TL/LoTE udelukkende til test og fejlfinding; ikke til produktion"
+	"extra_tl_lote_onboarding_catalogue_description": "Onboard EUDI-komponenter på TL/LoTE udelukkende til test og fejlfinding; ikke til produktion",
+	"Pipeline_notifications": "Pipeline-notifikationer",
+	"Pipeline_notifications_description": "Modtag en push-notifikation, når en pipelinekørsel er afsluttet.",
+	"Pipeline_notifications_enabled": "Pipeline-notifikationer aktiveret",
+	"Pipeline_notifications_disabled": "Pipeline-notifikationer deaktiveret",
+	"Failed_to_enable_pipeline_notifications": "Kunne ikke aktivere pipeline-notifikationer",
+	"Failed_to_disable_pipeline_notifications": "Kunne ikke deaktivere pipeline-notifikationer",
+	"Notifications_blocked_hint": "Notifikationer er blokeret for dette websted. Aktivér dem igen i browserens webstedsindstillinger.",
+	"Push_notifications_unsupported": "Denne browser understøtter ikke push-notifikationer."
 }

--- a/webapp/messages/de.json
+++ b/webapp/messages/de.json
@@ -1016,5 +1016,13 @@
 	"extra_eudi_atlas": "EUDI Atlas",
 	"extra_eudi_atlas_description": "Umfassende EUDI-Dokumentenkarte (nach Rolle organisiert) mit Konformitätstest-Leitfaden",
 	"extra_tl_lote_onboarding_catalogue": "TL/LoTE-Onboarding/Katalog",
-	"extra_tl_lote_onboarding_catalogue_description": "EUDI-Komponenten auf TL/LoTE nur für Tests und Debugging onboarden; nicht für den Produktionseinsatz"
+	"extra_tl_lote_onboarding_catalogue_description": "EUDI-Komponenten auf TL/LoTE nur für Tests und Debugging onboarden; nicht für den Produktionseinsatz",
+	"Pipeline_notifications": "Pipeline-Benachrichtigungen",
+	"Pipeline_notifications_description": "Erhalte eine Push-Benachrichtigung, wenn ein Pipeline-Durchlauf beendet ist.",
+	"Pipeline_notifications_enabled": "Pipeline-Benachrichtigungen aktiviert",
+	"Pipeline_notifications_disabled": "Pipeline-Benachrichtigungen deaktiviert",
+	"Failed_to_enable_pipeline_notifications": "Pipeline-Benachrichtigungen konnten nicht aktiviert werden",
+	"Failed_to_disable_pipeline_notifications": "Pipeline-Benachrichtigungen konnten nicht deaktiviert werden",
+	"Notifications_blocked_hint": "Benachrichtigungen sind für diese Website blockiert. Aktiviere sie in den Website-Einstellungen des Browsers erneut.",
+	"Push_notifications_unsupported": "Dieser Browser unterstützt keine Push-Benachrichtigungen."
 }

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -1048,5 +1048,13 @@
 	"extra_tl_lote_onboarding_catalogue": "TL/LoTE Onboarding/Catalogue",
 	"extra_tl_lote_onboarding_catalogue_description": "Onboard EUDI components on TL/LoTE(s) for testing and debugging only; not for production use",
 	"Extras": "Extras",
-	"executions_CI": "CI/CD"
+	"executions_CI": "CI/CD",
+	"Pipeline_notifications": "Pipeline notifications",
+	"Pipeline_notifications_description": "Receive a push notification when a pipeline run finishes.",
+	"Pipeline_notifications_enabled": "Pipeline notifications enabled",
+	"Pipeline_notifications_disabled": "Pipeline notifications disabled",
+	"Failed_to_enable_pipeline_notifications": "Failed to enable pipeline notifications",
+	"Failed_to_disable_pipeline_notifications": "Failed to disable pipeline notifications",
+	"Notifications_blocked_hint": "Notifications are blocked for this site. Re-enable them in your browser site settings.",
+	"Push_notifications_unsupported": "Push notifications are not supported by this browser."
 }

--- a/webapp/messages/es-es.json
+++ b/webapp/messages/es-es.json
@@ -1016,5 +1016,13 @@
 	"extra_eudi_atlas": "EUDI Atlas",
 	"extra_eudi_atlas_description": "Mapa completo de documentos EUDI (organizado por rol) con guía de pruebas de conformidad",
 	"extra_tl_lote_onboarding_catalogue": "Incorporación/Catálogo TL/LoTE",
-	"extra_tl_lote_onboarding_catalogue_description": "Incorpora componentes EUDI en TL/LoTE solo para pruebas y depuración; no para producción"
+	"extra_tl_lote_onboarding_catalogue_description": "Incorpora componentes EUDI en TL/LoTE solo para pruebas y depuración; no para producción",
+	"Pipeline_notifications": "Notificaciones de pipeline",
+	"Pipeline_notifications_description": "Recibe una notificación push cuando termina una ejecución de pipeline.",
+	"Pipeline_notifications_enabled": "Notificaciones de pipeline activadas",
+	"Pipeline_notifications_disabled": "Notificaciones de pipeline desactivadas",
+	"Failed_to_enable_pipeline_notifications": "No se pudieron activar las notificaciones de pipeline",
+	"Failed_to_disable_pipeline_notifications": "No se pudieron desactivar las notificaciones de pipeline",
+	"Notifications_blocked_hint": "Las notificaciones están bloqueadas para este sitio. Reactívalas en la configuración del sitio de tu navegador.",
+	"Push_notifications_unsupported": "Este navegador no admite notificaciones push."
 }

--- a/webapp/messages/fr.json
+++ b/webapp/messages/fr.json
@@ -1016,5 +1016,13 @@
 	"extra_eudi_atlas": "EUDI Atlas",
 	"extra_eudi_atlas_description": "Carte complète des documents EUDI (organisée par rôle) avec guide de tests de conformité",
 	"extra_tl_lote_onboarding_catalogue": "Intégration/Catalogue TL/LoTE",
-	"extra_tl_lote_onboarding_catalogue_description": "Intégrer des composants EUDI aux TL/LoTE uniquement pour les tests et le débogage ; pas pour la production"
+	"extra_tl_lote_onboarding_catalogue_description": "Intégrer des composants EUDI aux TL/LoTE uniquement pour les tests et le débogage ; pas pour la production",
+	"Pipeline_notifications": "Notifications de pipeline",
+	"Pipeline_notifications_description": "Recevez une notification push lorsqu’une exécution de pipeline se termine.",
+	"Pipeline_notifications_enabled": "Notifications de pipeline activées",
+	"Pipeline_notifications_disabled": "Notifications de pipeline désactivées",
+	"Failed_to_enable_pipeline_notifications": "Échec de l’activation des notifications de pipeline",
+	"Failed_to_disable_pipeline_notifications": "Échec de la désactivation des notifications de pipeline",
+	"Notifications_blocked_hint": "Les notifications sont bloquées pour ce site. Réactivez-les dans les paramètres du site de votre navigateur.",
+	"Push_notifications_unsupported": "Ce navigateur ne prend pas en charge les notifications push."
 }

--- a/webapp/messages/it.json
+++ b/webapp/messages/it.json
@@ -1022,5 +1022,13 @@
 	"extra_eudi_atlas": "EUDI Atlas",
 	"extra_eudi_atlas_description": "Mappa completa dei documenti EUDI (organizzata per ruolo) con guida ai test di conformità",
 	"extra_tl_lote_onboarding_catalogue": "Onboarding/Catalogo TL/LoTE",
-	"extra_tl_lote_onboarding_catalogue_description": "Onboarding dei componenti EUDI su TL/LoTE solo per test e debug; non per uso in produzione"
+	"extra_tl_lote_onboarding_catalogue_description": "Onboarding dei componenti EUDI su TL/LoTE solo per test e debug; non per uso in produzione",
+	"Pipeline_notifications": "Notifiche delle pipeline",
+	"Pipeline_notifications_description": "Ricevi una notifica push quando termina un’esecuzione della pipeline.",
+	"Pipeline_notifications_enabled": "Notifiche delle pipeline attivate",
+	"Pipeline_notifications_disabled": "Notifiche delle pipeline disattivate",
+	"Failed_to_enable_pipeline_notifications": "Impossibile attivare le notifiche delle pipeline",
+	"Failed_to_disable_pipeline_notifications": "Impossibile disattivare le notifiche delle pipeline",
+	"Notifications_blocked_hint": "Le notifiche sono bloccate per questo sito. Riattivale nelle impostazioni del sito del browser.",
+	"Push_notifications_unsupported": "Questo browser non supporta le notifiche push."
 }

--- a/webapp/messages/pt-BR.json
+++ b/webapp/messages/pt-BR.json
@@ -1016,5 +1016,13 @@
 	"extra_eudi_atlas": "EUDI Atlas",
 	"extra_eudi_atlas_description": "Mapa abrangente de documentos EUDI (organizado por função) com guia de testes de conformidade",
 	"extra_tl_lote_onboarding_catalogue": "Onboarding/Catálogo TL/LoTE",
-	"extra_tl_lote_onboarding_catalogue_description": "Faça o onboarding de componentes EUDI em TL/LoTE apenas para testes e depuração; não use em produção"
+	"extra_tl_lote_onboarding_catalogue_description": "Faça o onboarding de componentes EUDI em TL/LoTE apenas para testes e depuração; não use em produção",
+	"Pipeline_notifications": "Notificações de pipeline",
+	"Pipeline_notifications_description": "Receba uma notificação push quando uma execução de pipeline terminar.",
+	"Pipeline_notifications_enabled": "Notificações de pipeline ativadas",
+	"Pipeline_notifications_disabled": "Notificações de pipeline desativadas",
+	"Failed_to_enable_pipeline_notifications": "Falha ao ativar as notificações de pipeline",
+	"Failed_to_disable_pipeline_notifications": "Falha ao desativar as notificações de pipeline",
+	"Notifications_blocked_hint": "As notificações estão bloqueadas para este site. Reative-as nas configurações do site do navegador.",
+	"Push_notifications_unsupported": "Este navegador não é compatível com notificações push."
 }

--- a/webapp/src/lib/pipeline/web-push.spec.ts
+++ b/webapp/src/lib/pipeline/web-push.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest';
+
+import { urlBase64ToUint8Array } from './web-push';
+
+describe('urlBase64ToUint8Array', () => {
+	it('decodes base64 without padding', () => {
+		// atob('AQID') = bytes 0x01 0x02 0x03
+		expect(urlBase64ToUint8Array('AQID')).toEqual(new Uint8Array([1, 2, 3]));
+	});
+
+	it('adds missing padding', () => {
+		// 'AQ' must be padded to 'AQ==' before decoding
+		expect(urlBase64ToUint8Array('AQ')).toEqual(new Uint8Array([1]));
+	});
+
+	it('converts URL-safe characters', () => {
+		// '+' (62) and '/' (63) are sent as '-' and '_' in base64url
+		expect(urlBase64ToUint8Array('-_')).toEqual(new Uint8Array([0xfb]));
+	});
+
+	it('round-trips a 65-byte VAPID key', () => {
+		const raw = crypto.getRandomValues(new Uint8Array(65));
+		const encoded = Buffer.from(raw).toString('base64url');
+		expect(Array.from(urlBase64ToUint8Array(encoded))).toEqual(Array.from(raw));
+	});
+});

--- a/webapp/src/lib/pipeline/web-push.ts
+++ b/webapp/src/lib/pipeline/web-push.ts
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { browser } from '$app/environment';
+import { ClientResponseError } from 'pocketbase';
+import { err, ok, type Result } from 'true-myth/result';
+
+import { m } from '@/i18n';
+import { pb } from '@/pocketbase';
+import { getExceptionMessage } from '@/utils/errors';
+
+//
+
+export type NotificationState = 'unsupported' | 'denied' | 'off' | 'on';
+
+type PushSubscriptionKeys = {
+	p256dh: string;
+	auth: string;
+};
+
+const VAPID_PUBLIC_KEY_URL = '/api/web-push/vapid-public-key';
+
+export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+	const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+	const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+	const rawData = atob(base64);
+	const output = new Uint8Array(rawData.length);
+	for (let i = 0; i < rawData.length; ++i) output[i] = rawData.charCodeAt(i);
+	return output;
+}
+
+export async function getNotificationState(): Promise<NotificationState> {
+	if (!browser) return 'unsupported';
+	if (!('serviceWorker' in navigator && 'PushManager' in window)) return 'unsupported';
+	if (Notification.permission === 'denied') return 'denied';
+
+	// `getRegistration` resolves immediately (undefined when no worker exists),
+	// unlike `ready` which waits forever, so the profile page can never hang.
+	const registration = await navigator.serviceWorker.getRegistration();
+	if (!registration) return 'off';
+
+	try {
+		return (await registration.pushManager.getSubscription()) ? 'on' : 'off';
+	} catch {
+		// The registration can exist before the worker is active,
+		// in which case `getSubscription` throws.
+		return 'off';
+	}
+}
+
+export async function enablePipelineNotifications(): Promise<Result<null, string>> {
+	if (!browser) return err(m.Push_notifications_unsupported());
+
+	try {
+		if (!('serviceWorker' in navigator && 'PushManager' in window))
+			return err(m.Push_notifications_unsupported());
+
+		const permission = await Notification.requestPermission();
+		if (permission !== 'granted') return err(m.Failed_to_enable_pipeline_notifications());
+
+		const registration = await navigator.serviceWorker.ready;
+		let subscription = await registration.pushManager.getSubscription();
+		if (!subscription) {
+			const { public_key } = await pb.send<{ public_key: string }>(VAPID_PUBLIC_KEY_URL, {
+				method: 'GET'
+			});
+			subscription = await registration.pushManager.subscribe({
+				userVisibleOnly: true,
+				applicationServerKey: urlBase64ToUint8Array(public_key)
+			});
+		}
+
+		await saveSubscription(subscription);
+		return ok(null);
+	} catch (e) {
+		return err(getExceptionMessage(e));
+	}
+}
+
+export async function disablePipelineNotifications(): Promise<Result<null, string>> {
+	if (!browser) return ok(null);
+
+	try {
+		const registration = await navigator.serviceWorker.getRegistration();
+		const subscription = await registration?.pushManager.getSubscription();
+		if (subscription) {
+			await deleteSubscriptionRecords(subscription.endpoint);
+			await subscription.unsubscribe();
+		}
+		return ok(null);
+	} catch (e) {
+		return err(getExceptionMessage(e));
+	}
+}
+
+async function saveSubscription(subscription: PushSubscription): Promise<void> {
+	const { endpoint, keys } = subscription.toJSON() as {
+		endpoint?: string;
+		keys?: PushSubscriptionKeys;
+	};
+	const user = pb.authStore.record?.id;
+	if (!user || !endpoint || !keys?.p256dh || !keys.auth) {
+		throw new Error('Missing push subscription data');
+	}
+
+	try {
+		await pb.collection('push_subscriptions').create({ user, endpoint, keys });
+	} catch (e) {
+		// A unique-constraint conflict on `endpoint` means this browser is
+		// already registered: refresh its keys instead of failing.
+		if (!(e instanceof ClientResponseError)) throw e;
+		const existing = await findSubscriptionRecord(endpoint);
+		if (!existing) throw e;
+		await pb.collection('push_subscriptions').update(existing.id, { user, keys });
+	}
+}
+
+async function deleteSubscriptionRecords(endpoint: string): Promise<void> {
+	const user = pb.authStore.record?.id;
+	if (!user) return;
+
+	const record = await findSubscriptionRecord(endpoint);
+
+	if (record) {
+		await pb.collection('push_subscriptions').delete(record.id);
+		return;
+	}
+
+	// No record matches this endpoint (e.g. the browser lost the subscription):
+	// clear all of the user's records so no stale subscription keeps pushing.
+
+	const records = await pb.collection('push_subscriptions').getFullList({
+		filter: `user = "${user}"`
+	});
+	await Promise.all(records.map((r) => pb.collection('push_subscriptions').delete(r.id)));
+}
+
+async function findSubscriptionRecord(endpoint: string) {
+	return pb
+		.collection('push_subscriptions')
+		.getFirstListItem(`user = "${pb.authStore.record?.id}" && endpoint = "${endpoint}"`)
+		.catch(() => null);
+}

--- a/webapp/src/lib/pipeline/web-push.ts
+++ b/webapp/src/lib/pipeline/web-push.ts
@@ -58,8 +58,12 @@ export async function enablePipelineNotifications(): Promise<Result<null, string
 
 		const permission = await Notification.requestPermission();
 		if (permission !== 'granted') return err(m.Failed_to_enable_pipeline_notifications());
-
-		const registration = await navigator.serviceWorker.ready;
+		// SvelteKit registers the service worker automatically, but fall
+		// back to an explicit registration so the toggle cannot hang on
+		// `ready` if the automatic registration has not happened yet.
+		const registration =
+			(await navigator.serviceWorker.getRegistration()) ??
+			(await navigator.serviceWorker.register('/service-worker.js'));
 		let subscription = await registration.pushManager.getSubscription();
 		if (!subscription) {
 			const { public_key } = await pb.send<{ public_key: string }>(VAPID_PUBLIC_KEY_URL, {
@@ -110,7 +114,9 @@ async function saveSubscription(subscription: PushSubscription): Promise<void> {
 		// A unique-constraint conflict on `endpoint` means this browser is
 		// already registered: refresh its keys instead of failing.
 		if (!(e instanceof ClientResponseError)) throw e;
-		const existing = await findSubscriptionRecord(endpoint);
+		const user = pb.authStore.record?.id;
+		if (!user) throw e;
+		const existing = await findSubscriptionRecord(user, endpoint);
 		if (!existing) throw e;
 		await pb.collection('push_subscriptions').update(existing.id, { user, keys });
 	}
@@ -120,7 +126,7 @@ async function deleteSubscriptionRecords(endpoint: string): Promise<void> {
 	const user = pb.authStore.record?.id;
 	if (!user) return;
 
-	const record = await findSubscriptionRecord(endpoint);
+	const record = await findSubscriptionRecord(user, endpoint);
 
 	if (record) {
 		await pb.collection('push_subscriptions').delete(record.id);
@@ -129,16 +135,15 @@ async function deleteSubscriptionRecords(endpoint: string): Promise<void> {
 
 	// No record matches this endpoint (e.g. the browser lost the subscription):
 	// clear all of the user's records so no stale subscription keeps pushing.
-
 	const records = await pb.collection('push_subscriptions').getFullList({
-		filter: `user = "${user}"`
+		filter: pb.filter('user = {:user}', { user })
 	});
 	await Promise.all(records.map((r) => pb.collection('push_subscriptions').delete(r.id)));
 }
 
-async function findSubscriptionRecord(endpoint: string) {
+async function findSubscriptionRecord(user: string, endpoint: string) {
 	return pb
 		.collection('push_subscriptions')
-		.getFirstListItem(`user = "${pb.authStore.record?.id}" && endpoint = "${endpoint}"`)
+		.getFirstListItem(pb.filter('user = {:user} && endpoint = {:endpoint}', { user, endpoint }))
 		.catch(() => null);
 }

--- a/webapp/src/routes/my/profile/+page.svelte
+++ b/webapp/src/routes/my/profile/+page.svelte
@@ -6,6 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <script lang="ts">
 	import { Pencil } from '@lucide/svelte';
+	import {
+		disablePipelineNotifications,
+		enablePipelineNotifications,
+		getNotificationState,
+		type NotificationState
+	} from '$lib/pipeline/web-push';
+	import { toast } from 'svelte-sonner';
 	import { zod } from 'sveltekit-superforms/adapters';
 	import z from 'zod/v3';
 
@@ -13,6 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import T from '@/components/ui-custom/t.svelte';
 	import UserAvatar from '@/components/ui-custom/userAvatar.svelte';
 	import Separator from '@/components/ui/separator/separator.svelte';
+	import { Switch } from '@/components/ui/switch';
 	import { Form, createForm } from '@/forms';
 	import { CheckboxField, Field, FileField, SelectField } from '@/forms/fields';
 	import { m } from '@/i18n';
@@ -56,6 +64,29 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	setDashboardNavbar({
 		title: m.Profile()
 	});
+
+	let pushState: NotificationState = $state('off');
+	let pushUpdating = $state(false);
+
+	$effect(() => {
+		getNotificationState().then((state) => (pushState = state));
+	});
+
+	async function togglePipelineNotifications(checked: boolean) {
+		pushUpdating = true;
+		const result = checked
+			? await enablePipelineNotifications()
+			: await disablePipelineNotifications();
+		pushState = await getNotificationState();
+		pushUpdating = false;
+		if (result.isOk) {
+			toast.success(
+				checked ? m.Pipeline_notifications_enabled() : m.Pipeline_notifications_disabled()
+			);
+		} else {
+			toast.error(result.error);
+		}
+	}
 </script>
 
 <div class="space-y-6">
@@ -109,4 +140,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			{/snippet}
 		</Form>
 	{/key}
+
+	<Separator />
+
+	<div class="flex items-center justify-between gap-4">
+		<div class="space-y-1">
+			<T tag="h4">{m.Pipeline_notifications()}</T>
+			<T tag="p" class="text-sm text-gray-400">{m.Pipeline_notifications_description()}</T>
+			{#if pushState === 'denied'}
+				<T tag="p" class="text-sm text-gray-400">{m.Notifications_blocked_hint()}</T>
+			{:else if pushState === 'unsupported'}
+				<T tag="p" class="text-sm text-gray-400">{m.Push_notifications_unsupported()}</T>
+			{/if}
+		</div>
+		<Switch
+			aria-label={m.Pipeline_notifications()}
+			checked={pushState === 'on'}
+			disabled={pushState === 'unsupported' || pushUpdating}
+			onCheckedChange={togglePipelineNotifications}
+		/>
+	</div>
 </div>

--- a/webapp/src/service-worker.ts
+++ b/webapp/src/service-worker.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Forkbomb BV
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// <reference types="@sveltejs/kit" />
+/// <reference lib="webworker" />
+
+// The webworker lib reference gives this file ServiceWorkerGlobalScope types
+// without switching the rest of the app away from the DOM lib.
+// `self` still resolves to DOM's Window under svelte-check, hence the cast.
+const sw = self as unknown as ServiceWorkerGlobalScope;
+
+// Plain English strings: paraglide's locale strategies (url/cookie) need
+// window/document APIs that are unavailable in the service worker context.
+const PUSH_RESULT_TITLE: Record<string, string> = {
+	success: 'completed',
+	failed: 'failed',
+	canceled: 'canceled'
+};
+
+const FALLBACK_TITLE = 'finished';
+
+const NOTIFICATION_ICON = '/logos/credimi_logo-transp_emblem.png';
+
+type PushPayload = {
+	pipeline_name: string;
+	organization?: string;
+	result: string;
+	duration?: string;
+	error?: string;
+	url: string;
+};
+
+sw.addEventListener('push', (event) => {
+	const payload = parsePushPayload(event.data?.text());
+	if (!payload?.url) return;
+
+	const title = `${payload.pipeline_name} — ${PUSH_RESULT_TITLE[payload.result] ?? FALLBACK_TITLE}`;
+
+	event.waitUntil(
+		sw.registration.showNotification(title, {
+			body: buildPushBody(payload),
+			icon: NOTIFICATION_ICON,
+			tag: payload.url,
+			data: { url: payload.url }
+		})
+	);
+});
+
+function buildPushBody(payload: PushPayload): string {
+	const context: string[] = [];
+	if (payload.organization) context.push(`in ${payload.organization}`);
+	if (payload.duration) context.push(`after ${payload.duration}`);
+
+	const lines: string[] = [];
+	if (context.length > 0) {
+		const sentence = context.join(' ');
+		lines.push(sentence.charAt(0).toUpperCase() + sentence.slice(1) + '.');
+	}
+	if (payload.error) lines.push(payload.error);
+
+	return lines.join('\n');
+}
+
+sw.addEventListener('notificationclick', (event) => {
+	event.notification.close();
+
+	const url: unknown = event.notification.data?.url;
+	if (typeof url !== 'string' || !url) return;
+
+	event.waitUntil(
+		sw.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async (clients) => {
+			for (const client of clients) {
+				await client.focus();
+				if ('navigate' in client) await client.navigate(url);
+				return;
+			}
+			await sw.clients.openWindow(url);
+		})
+	);
+});
+
+function parsePushPayload(raw: string | undefined): PushPayload | null {
+	if (!raw) return null;
+	try {
+		const data = JSON.parse(raw) as Partial<PushPayload>;
+		if (typeof data.pipeline_name !== 'string' || typeof data.url !== 'string') return null;
+		return {
+			pipeline_name: data.pipeline_name,
+			organization: typeof data.organization === 'string' ? data.organization : undefined,
+			result: data.result ?? '',
+			duration: typeof data.duration === 'string' ? data.duration : undefined,
+			error: typeof data.error === 'string' ? data.error : undefined,
+			url: data.url
+		};
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## What

Telegram/Drive-style web notifications when a pipeline run finishes. Organization members get a system-level notification on **every terminal state** — completed, failed, or canceled — including when the tab or browser is closed (Web Push, buffered up to 1h TTL).

Failed runs carry the root cause (CRE code + summary) extracted from the workflow error; all runs show organization name and duration. Clicking the notification opens the run page.

## How

- **Server**: `pkg/internal/webpush` — VAPID key manager (env override `CREDIMI_WEB_PUSH_VAPID_*`, else auto-generated + persisted in new superuser-only `web_push_settings` collection) and the Web Push sender (encrypted aes128gcm, TTL 3600, dead-subscription pruning on 404/410). Dependency: `github.com/SherClockHolmes/webpush-go v1.4.0`.
- **Trigger**: end-of-workflow activity in the pipeline workflow's all-outcomes defer (`pipeline.go`), mirroring `reportMobileRunnerSemaphoreDone`. Guarded by the `pipeline_completion_notification` config key injected by the queue handler for **both** start paths — direct start (non-runner pipelines) and runner semaphore — with a regression test on the direct path.
- **API**: `GET /api/web-push/vapid-public-key` (public) and `POST /api/web-push/pipeline-completed` (`RequireInternalAdminAPIKey`), resolving pipeline name, org, and members from `pipeline_results` + `orgAuthorizations`.
- **Webapp**: SvelteKit service worker (`push` → showNotification, `notificationclick` → focus/navigate), subscription client module (`webapp/src/lib/pipeline/web-push.ts`), Profile → "Pipeline notifications" switch, i18n in all 7 locales. Subscriptions stored in new user-scoped `push_subscriptions` collection (users can only touch their own records).

## Verification

- `make lint` (tidy, verify, vet, govulncheck, golangci-lint): green, 0 issues
- `make test`: 1292/1296 passed (4 skipped); new unit tests for VAPID generation/persistence, sender, activity, defer wiring (success + guard), and the direct-start config injection
- `bun run check` 0 errors; webapp unit tests 177/177; `bun run build` ✔
- Live end-to-end on dev stack: VAPID route → real Firefox FCM/autopush subscription → `{"sent":1}` encrypted delivery (verified TTL/VAPID JWT/aes128gcm at the push endpoint) → notification rendered + clicked through; automatic firing verified from real run history after the queue-handler injection fix

## Production notes

- Set stable `CREDIMI_WEB_PUSH_VAPID_PUBLIC_KEY` / `CREDIMI_WEB_PUSH_VAPID_PRIVATE_KEY` in prod env (unset ⇒ auto-generated, persisted, but tied to the DB).
- Reuses the existing `CREDIMI_INTERNAL_ADMIN_KEY` runtime contract.
- No user migration: per-browser opt-in via the profile toggle.

## Known pre-existing (not from this PR)

- `TestCESRValidate_Execute` fails identically on `main` (upstream `et-tu-cesr` "latest" drift)
- webapp eslint has 2 pre-existing errors in `fcaf-report-sheet.svelte`
- `revive` not runnable locally (not installed); CI action will exercise it