### PR TITLE
fix(scoreboard): polish table chrome and hide native scrollbar

### DIFF
--- a/webapp/src/lib/scoreboard/columns/headers/entity-header.svelte
+++ b/webapp/src/lib/scoreboard/columns/headers/entity-header.svelte
@@ -39,7 +39,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <div
 	class={[
-		'relative flex items-center gap-1.5',
+		'flex items-center gap-1',
 		{
 			'justify-start': align === 'left',
 			'justify-center': align === 'center',
@@ -48,16 +48,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	]}
 >
 	<span
-		class="inline-flex items-center gap-1.5 text-[11px] font-medium tracking-[0.08em] whitespace-nowrap text-muted-foreground uppercase"
+		class="inline-flex items-center gap-1.5 text-[11px] font-medium tracking-[0.08em] whitespace-nowrap text-primary uppercase"
 	>
 		{#if props.data?.icon && !props.hideIcon}
 			<props.data.icon class="size-3.5" />
 		{/if}
 		{label}
 	</span>
-	<div class="absolute top-0 right-0 translate-x-3 -translate-y-1">
-		{#if ctx.header.column.getCanSort() && ctx.header.column.columnDef.meta?.manualPillPositioning}
-			<SortHeaderPill header={ctx.header} table={ctx.table} />
-		{/if}
-	</div>
+	{#if ctx.header.column.getCanSort() && ctx.header.column.columnDef.meta?.manualPillPositioning}
+		<SortHeaderPill header={ctx.header} table={ctx.table} />
+	{/if}
 </div>

--- a/webapp/src/lib/scoreboard/columns/last-execution.svelte
+++ b/webapp/src/lib/scoreboard/columns/last-execution.svelte
@@ -19,7 +19,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		header: renderComponent(EntityHeader, {
 			label: m.scoreboard_last_run()
 		}),
-		sortField: 'latest_successful_execution.created'
+		sortField: 'latest_successful_execution.created',
+		manualPillPositioning: true
 	});
 </script>
 

--- a/webapp/src/lib/scoreboard/entity-display/avatar.svelte
+++ b/webapp/src/lib/scoreboard/entity-display/avatar.svelte
@@ -30,7 +30,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	{#if link}
 		<a
 			href={resolve(localizeHref(item.href) as '/')}
-			class="relative inline-flex shrink-0 rounded-sm ring-2 ring-transparent hover:ring-primary"
+			class="relative inline-flex shrink-0 rounded-sm ring-2 ring-transparent hover:ring-primary focus-visible:outline-2"
 		>
 			{@render content()}
 		</a>

--- a/webapp/src/lib/scoreboard/entity-display/item.svelte
+++ b/webapp/src/lib/scoreboard/entity-display/item.svelte
@@ -44,20 +44,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<div class="flex flex-wrap items-center gap-1.5">
 			{#each item.children as child (child.href)}
 				<Tooltip>
-					<a href={child.href} class="rounded-sm focus-visible:outline-2">
-						{#if child.avatar}
-							<EntityAvatar
-								item={{
-									key: child.href,
-									name: child.label,
-									href: child.href,
-									avatar: child.avatar
-								}}
-							/>
-						{:else}
-							<span class="text-xs hover:underline">{child.label}</span>
-						{/if}
-					</a>
+					{#if child.avatar}
+						<EntityAvatar
+							item={{
+								key: child.href,
+								name: child.label,
+								href: child.href,
+								avatar: child.avatar
+							}}
+							link
+						/>
+					{:else}
+						<a
+							href={child.href}
+							class="rounded-sm text-xs hover:underline focus-visible:outline-2"
+						>
+							{child.label}
+						</a>
+					{/if}
 					{#snippet content()}
 						<p class="text-xs font-semibold">{child.label}</p>
 					{/snippet}

--- a/webapp/src/lib/scoreboard/table.svelte
+++ b/webapp/src/lib/scoreboard/table.svelte
@@ -50,10 +50,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import { ChevronDownIcon } from '@lucide/svelte';
 
 	import HorizontalScrollArea from '@/components/ui-custom/horizontal-scroll-area.svelte';
+	import SearchInput from '@/components/ui-custom/search-input.svelte';
 	import Button from '@/components/ui/button/button.svelte';
 	import { FlexRender } from '@/components/ui/data-table/index.js';
 	import * as DropdownMenu from '@/components/ui/dropdown-menu/index.js';
-	import Input from '@/components/ui/input/input.svelte';
 	import * as Pagination from '@/components/ui/pagination/index.js';
 	import * as Select from '@/components/ui/select/index.js';
 	import * as Table from '@/components/ui/table/index.js';
@@ -117,12 +117,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <div class="space-y-4">
 	<div class="flex flex-wrap items-center gap-2">
-		<Input
-			type="search"
-			placeholder={m.Search()}
+		<SearchInput
 			class="w-56"
 			bind:value={searchInput}
 			oninput={onSearchInput}
+			onclear={() => {
+				clearTimeout(searchDebounce);
+				applyFilters();
+			}}
 		/>
 		<Select.Root
 			type="single"
@@ -132,7 +134,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				applyFilters();
 			}}
 		>
-			<Select.Trigger class="w-40">
+			<Select.Trigger class="w-40 bg-background">
 				{BAND_FILTERS.find((option) => option.value === bandFilter)?.label}
 			</Select.Trigger>
 			<Select.Content>
@@ -149,6 +151,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					<Button {...props} variant="outline" size="sm">
 						<Columns3Icon class="size-4" />
 						{m.Columns()}
+						<ChevronDownIcon class="size-4 opacity-50" />
 					</Button>
 				{/snippet}
 			</DropdownMenu.Trigger>
@@ -174,7 +177,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<table class="w-max min-w-full caption-bottom text-sm">
 			<Table.Header>
 				{#each scoreboard.table.getHeaderGroups() as headerGroup (headerGroup.id)}
-					<Table.Row class="bg-secondary">
+					<Table.Row class="bg-[#d1c8f3] hover:bg-[#d1c8f3]">
 						<Table.Head class="w-10"></Table.Head>
 						{#each headerGroup.headers as header (header.id)}
 							{#if header.column.getIsVisible()}
@@ -217,15 +220,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					{@const isExpanded = expandedRowId === row.id}
 					<Table.Row
 						data-state={row.getIsSelected() && 'selected'}
-						class="cursor-pointer hover:bg-secondary data-[state=selected]:bg-secondary {isExpanded
-							? 'bg-secondary'
+						class="cursor-pointer hover:bg-muted/50 data-[state=selected]:bg-muted/30 {isExpanded
+							? 'bg-muted/30'
 							: ''}"
 						onclick={(event) => onRowClick(event, row.id)}
 					>
 						<Table.Cell class="align-top">
 							<button
 								type="button"
-								class="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-secondary hover:text-foreground focus-visible:outline-2"
+								class="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/50 hover:text-foreground focus-visible:outline-2"
 								aria-expanded={isExpanded}
 								aria-label={isExpanded ? m.Collapse() : m.Expand()}
 								onclick={() => toggleRow(row.id)}
@@ -247,7 +250,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						{/each}
 					</Table.Row>
 					{#if isExpanded}
-						<Table.Row class="bg-secondary hover:bg-secondary">
+						<Table.Row class="bg-muted/30 hover:bg-muted/30">
 							<Table.Cell colspan={row.getVisibleCells().length + 1} class="p-0!">
 								<RowDetails record={row.original} />
 							</Table.Cell>

--- a/webapp/src/lib/scoreboard/table.svelte.ts
+++ b/webapp/src/lib/scoreboard/table.svelte.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import type { ListResult } from 'pocketbase';
+
 import {
 	getCoreRowModel,
 	type PaginationState,
@@ -45,7 +47,7 @@ interface ExtendedPaginationState extends PaginationState {
 
 interface Options {
 	pageSize?: number;
-	initialData?: () => ScoreboardRow[];
+	initialPage?: () => ListResult<ScoreboardRow>;
 }
 
 export class ScoreboardTable {
@@ -155,14 +157,25 @@ export class ScoreboardTable {
 		});
 
 		onMount(() => {
-			if (!options.initialData) this.loadData();
+			if (!options.initialPage) this.loadData();
 		});
 
 		$effect(() => {
-			if (options.initialData) {
-				this.#data = options.initialData();
+			if (options.initialPage) {
+				this.applyPageResult(options.initialPage());
 			}
 		});
+	}
+
+	private applyPageResult(res: ListResult<ScoreboardRow>) {
+		const normalizedApiPage = fromApiPage(res.page);
+		this.#data = res.items;
+		this.#pagination = {
+			pageSize: res.perPage,
+			pageIndex: toTableIndex(normalizedApiPage),
+			pageCount: res.totalPages,
+			totalItems: res.totalItems
+		};
 	}
 
 	private async loadData() {
@@ -174,14 +187,7 @@ export class ScoreboardTable {
 			...(sort ? { sort } : {}),
 			...(this.#filter ? { filter: this.#filter } : {})
 		});
-		const normalizedApiPage = fromApiPage(res.page);
-		this.#data = res.items;
-		this.#pagination = {
-			pageSize: res.perPage,
-			pageIndex: toTableIndex(normalizedApiPage),
-			pageCount: res.totalPages,
-			totalItems: res.totalItems
-		};
+		this.applyPageResult(res);
 	}
 }
 

--- a/webapp/src/modules/components/ui-custom/horizontal-scroll-area.svelte
+++ b/webapp/src/modules/components/ui-custom/horizontal-scroll-area.svelte
@@ -252,7 +252,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		id={contentId}
 		bind:this={contentEl}
 		data-slot="table-container"
-		class={cn('scrollbar-hide w-full overflow-x-auto', contentClass)}
+		class={cn('scrollbar-none w-full overflow-x-auto overflow-y-hidden', contentClass)}
 		onscroll={onContentScroll}
 	>
 		{@render children?.()}

--- a/webapp/src/modules/components/ui-custom/navigationTabs.svelte
+++ b/webapp/src/modules/components/ui-custom/navigationTabs.svelte
@@ -50,7 +50,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		</div>
 	{/if}
 
-	<ul class="scrollbar-hide flex gap-1 overflow-x-auto">
+	<ul class="scrollbar-none flex gap-1 overflow-x-auto">
 		{#each tabs as tab (tab.href)}
 			<li role="presentation" class="flex-shrink-0">
 				<NavigationTab {...tab} />

--- a/webapp/src/modules/components/ui-custom/search-input.svelte
+++ b/webapp/src/modules/components/ui-custom/search-input.svelte
@@ -1,0 +1,65 @@
+<!--
+SPDX-FileCopyrightText: 2026 Forkbomb BV
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+	import type { ClassValue } from 'svelte/elements';
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	import { SearchIcon, XIcon } from '@lucide/svelte';
+
+	import IconButton from '@/components/ui-custom/iconButton.svelte';
+	import Input from '@/components/ui/input/input.svelte';
+	import { cn } from '@/components/ui/utils';
+	import { m } from '@/i18n';
+
+	//
+
+	type Props = Omit<HTMLInputAttributes, 'type' | 'value' | 'files'> & {
+		value?: string;
+		class?: ClassValue;
+		inputClass?: ClassValue;
+		onclear?: () => void;
+	};
+
+	let {
+		value = $bindable(''),
+		class: className,
+		inputClass,
+		onclear,
+		placeholder = m.Search(),
+		...restProps
+	}: Props = $props();
+
+	function clear() {
+		value = '';
+		onclear?.();
+	}
+</script>
+
+<div class={cn('relative', className)}>
+	<SearchIcon
+		class="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 opacity-50"
+		aria-hidden="true"
+	/>
+	<Input
+		type="search"
+		class={cn('pr-9 pl-9 text-sm', inputClass)}
+		bind:value
+		{placeholder}
+		{...restProps}
+	/>
+	{#if value}
+		<div class="absolute top-0 right-0 p-1">
+			<IconButton
+				icon={XIcon}
+				variant="ghost"
+				size="sm"
+				aria-label={m.Clear()}
+				onclick={clear}
+			/>
+		</div>
+	{/if}
+</div>

--- a/webapp/src/routes/(public)/scoreboard/+page.svelte
+++ b/webapp/src/routes/(public)/scoreboard/+page.svelte
@@ -16,7 +16,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 	const scoreboard = new Scoreboard.Instance({
 		pageSize: 20,
-		initialData: () => data.scoreboardData
+		initialPage: () => data.scoreboardPage
 	});
 </script>
 

--- a/webapp/src/routes/(public)/scoreboard/+page.ts
+++ b/webapp/src/routes/(public)/scoreboard/+page.ts
@@ -5,13 +5,13 @@
 import { Scoreboard } from '$lib';
 
 export const load = async ({ fetch }) => {
-	const data = await Scoreboard.Records.loadPage({
+	const scoreboardPage = await Scoreboard.Records.loadPage({
 		fetch,
 		perPage: 20,
 		page: 1,
 		sort: '-latest_successful_execution.created'
 	});
 	return {
-		scoreboardData: data.items
+		scoreboardPage
 	};
 };


### PR DESCRIPTION
## Summary

- Hide the native horizontal scrollbar in `HorizontalScrollArea` / nav tabs (`scrollbar-none`, `overflow-y-hidden`) so only the custom pinned bar shows
- Fix scoreboard pagination on first paint by applying the full SSR page result (`pageCount` / totals), not only row items
- Polish the scoreboard toolbar: reusable search input with lens + clear, band filter background, Columns chevron
- Restore thead lavender (`bg-[#d1c8f3]`) with locked hover, primary uppercase header labels, and inline sort pills (no overlap)
- Soften row hover to `bg-muted/50` and unify avatar hover rings across entity-display layouts

## Test plan

- [ ] Open `/scoreboard` on a wide viewport with horizontal overflow
- [ ] Confirm only the custom horizontal scrollbar is visible; no native double bar when scrolling vertically
- [ ] Confirm pagination appears on first load without searching
- [ ] Check Search (icon + clear), band filter background, and Columns chevron
- [ ] Confirm thead color/text and that sort pills sit beside labels without overlapping
- [ ] Hover rows (muted/50) and entity avatars (consistent ring) across wallets / issuance / presentations