### PR TITLE
fix(pipelines): expand owner for owned pipelines on my pipelines page

### DIFF
--- a/webapp/src/routes/my/pipelines/+page.svelte
+++ b/webapp/src/routes/my/pipelines/+page.svelte
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		queryOptions={{
 			filter: `owner.id = '${userOrganization.current?.id}'`,
 			sort: ['created', 'DESC'],
-			expand: ['schedules_via_pipeline']
+			expand: ['schedules_via_pipeline', 'owner']
 		}}
 		hide={['pagination']}
 	>


### PR DESCRIPTION
## Problem

On `/my/pipelines`, owned org pipelines did not show the org picture.

## Cause

`PipelineCard` derives the avatar from `pipeline.expand?.owner.logo` (`webapp/src/routes/my/pipelines/_partials/pipeline-card.svelte`), but the "Your Pipelines" `CollectionManager` query expanded only `schedules_via_pipeline`, so `expand.owner` was never present. The "Other Pipelines" section already expanded `owner`, which is why their pictures rendered.

## Fix

Add `owner` to the expand list in `webapp/src/routes/my/pipelines/+page.svelte`.