### PR TITLE
fix(pipeline): use catalog FCAF entry

### DIFF
--- a/webapp/src/lib/pipeline-form/steps/conformance-check/conformance-check-step-form.svelte
+++ b/webapp/src/lib/pipeline-form/steps/conformance-check/conformance-check-step-form.svelte
@@ -107,15 +107,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<WithLabel label={m.Select_item({ item: selectLabel.toLowerCase() })} class="p-4">
 				<div class="space-y-2 pt-1">
 					{#if form.state == 'select-standard'}
-						<ItemCard
-							title={m.FCAF()}
-							subtitle={m.FCAF_subtitle()}
-							onClick={() => form.selectFCAF()}
-						/>
 						{#each standards as standard (standard.uid)}
 							<ItemCard
 								title={standard.name}
-								onClick={() => form.selectStandard(standard)}
+								subtitle={standard.uid === 'fcaf' ? m.FCAF_subtitle() : undefined}
+								onClick={() =>
+									standard.uid === 'fcaf'
+										? form.selectFCAF()
+										: form.selectStandard(standard)}
 							/>
 						{/each}
 					{:else if form.state === 'select-version'}


### PR DESCRIPTION
## Summary
- render FCAF from standards catalog instead of a separate hardcoded card
- preserve FCAF subtitle and dedicated validation-step navigation
- prevent duplicate FCAF choices

## Validation
- `bunx prettier --write src/lib/pipeline-form/steps/conformance-check/conformance-check-step-form.svelte`
- `bunx eslint src/lib/pipeline-form/steps/conformance-check/conformance-check-step-form.svelte`
- `bun run check` (0 errors; 55 existing warnings)
- `bun run test:unit -- --run` (33 files, 177 tests passed)

Full `bun run lint` remains blocked by two pre-existing `svelte/prefer-svelte-reactivity` errors in `src/lib/pipeline/results/fcaf-report-sheet.svelte`.