### PR TITLE
fix(webapp): constrain schedule runner picker

### DIFF
--- a/webapp/messages/da.json
+++ b/webapp/messages/da.json
@@ -955,6 +955,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Nuværende runner",
 	"Runner_configuration_not_available": "Kørner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "Der er flere runners. Rul for at se alle {count}.",
 	"Runner_status_checking": "Checking runner status…",
 	"Failed_to_enqueue_pipeline": "Mislykkedes to enqueue pipeline",
 	"Pipeline_queued": "Pipeline queued (position {position})",

--- a/webapp/messages/de.json
+++ b/webapp/messages/de.json
@@ -955,6 +955,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Aktuell runner",
 	"Runner_configuration_not_available": "Ausführenner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "Weitere Runner sind verfügbar. Scrollen Sie, um alle {count} anzuzeigen.",
 	"Runner_status_checking": "Checking runner status…",
 	"Failed_to_enqueue_pipeline": "Fehlgeschlagen to enqueue pipeline",
 	"Pipeline_queued": "Pipeline queued (position {position})",

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -970,6 +970,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Current runner",
 	"Runner_configuration_not_available": "Runner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "More runners are available. Scroll to view all {count}.",
 	"Runner_offline_run_disabled": "The selected runner is currently offline. To run this pipeline, please select a different runner.",
 	"Runner_status_checking": "Checking runner status…",
 	"Runner_offline_select_disabled": "This runner appears currently offline, therefore you may not select it for execution",

--- a/webapp/messages/es-es.json
+++ b/webapp/messages/es-es.json
@@ -955,6 +955,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Actual runner",
 	"Runner_configuration_not_available": "Ejecutarner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "Hay más runners disponibles. Desplázate para ver los {count}.",
 	"Runner_status_checking": "Checking runner status…",
 	"Failed_to_enqueue_pipeline": "Fallido to enqueue pipeline",
 	"Pipeline_queued": "Pipeline queued (position {position})",

--- a/webapp/messages/fr.json
+++ b/webapp/messages/fr.json
@@ -955,6 +955,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Actuel runner",
 	"Runner_configuration_not_available": "Exécuterner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "D’autres runners sont disponibles. Faites défiler pour afficher les {count}.",
 	"Runner_status_checking": "Checking runner status…",
 	"Failed_to_enqueue_pipeline": "Échec to enqueue pipeline",
 	"Pipeline_queued": "Pipeline queued (position {position})",

--- a/webapp/messages/it.json
+++ b/webapp/messages/it.json
@@ -955,6 +955,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Corrente runner",
 	"Runner_configuration_not_available": "Eseguiner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "Sono disponibili altri runner. Scorri per visualizzarli tutti e {count}.",
 	"Runner_status_checking": "Checking runner status…",
 	"Failed_to_enqueue_pipeline": "Non riuscito to enqueue pipeline",
 	"Pipeline_queued": "Pipeline queued (position {position})",

--- a/webapp/messages/pt-BR.json
+++ b/webapp/messages/pt-BR.json
@@ -955,6 +955,7 @@
 	"Configure_the_runner_for_this_pipeline": "Configure the runner for this pipeline",
 	"Current_runner": "Atual runner",
 	"Runner_configuration_not_available": "Executarner configuration not available for pipelines with specific runner steps",
+	"runner_picker_scroll_hint": "Há mais runners disponíveis. Role para ver todos os {count}.",
 	"Runner_status_checking": "Checking runner status…",
 	"Failed_to_enqueue_pipeline": "Falha to enqueue pipeline",
 	"Pipeline_queued": "Pipeline queued (position {position})",

--- a/webapp/src/lib/pipeline/runner/runner-select-input.svelte
+++ b/webapp/src/lib/pipeline/runner/runner-select-input.svelte
@@ -26,6 +26,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		selectedRunner?: string;
 		name?: string;
 		required?: boolean;
+		constrainResults?: boolean;
 	};
 
 	let {
@@ -33,13 +34,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		onSelect,
 		selectedRunner,
 		name,
-		required = false
+		required = false,
+		constrainResults = false
 	}: Props = $props();
 
 	const runnerCatalog = bindRunnerCatalogSearch();
 </script>
 
-{#if runnerCatalog.catalogLoading}
+{#snippet runnerResults()}
 	<RunnerSelectList
 		{presentation}
 		foundRunners={runnerCatalog.foundRunners}
@@ -47,6 +49,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		{onSelect}
 		{selectedRunner}
 	/>
+{/snippet}
+
+{#if runnerCatalog.catalogLoading}
+	{@render runnerResults()}
 {:else}
 	<div class="space-y-3" transition:fly>
 		<div class="space-y-2">
@@ -59,12 +65,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<SearchInput search={runnerCatalog.runnerSearch} {name} />
 		</div>
 
-		<RunnerSelectList
-			{presentation}
-			foundRunners={runnerCatalog.foundRunners}
-			catalogLoading={runnerCatalog.catalogLoading}
-			{onSelect}
-			{selectedRunner}
-		/>
+		{#if constrainResults}
+			<div class="max-h-64 overflow-y-auto pr-2" role="region" aria-label={m.Runners()}>
+				{@render runnerResults()}
+			</div>
+			{#if runnerCatalog.foundRunners.length > 5}
+				<p class="text-xs text-muted-foreground" aria-live="polite">
+					{m.runner_picker_scroll_hint({ count: runnerCatalog.foundRunners.length })}
+				</p>
+			{/if}
+		{:else}
+			{@render runnerResults()}
+		{/if}
 	</div>
 {/if}

--- a/webapp/src/routes/my/pipelines/_partials/schedule-pipeline-form.svelte
+++ b/webapp/src/routes/my/pipelines/_partials/schedule-pipeline-form.svelte
@@ -82,7 +82,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	}
 </script>
 
-<Dialog bind:open={isOpen} title={m.Schedule_pipeline()}>
+<Dialog
+	bind:open={isOpen}
+	title={m.Schedule_pipeline()}
+	contentClass="max-h-[calc(100dvh-2rem)] overflow-y-auto"
+>
 	{#snippet trigger({ props })}
 		<IconButton {...props} icon={CalendarIcon} tooltip={m.Schedule_pipeline()} />
 	{/snippet}
@@ -128,6 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					onSelect={onRunnerSelect}
 					selectedRunner={($formData as { global_runner_id?: string }).global_runner_id}
 					required
+					constrainResults
 				/>
 			{/if}
 


### PR DESCRIPTION
## Problem

The pipeline schedule dialog renders every runner in document flow with no height cap. With more than five runners the list pushes the **Schedule** CTA below the viewport, making it unreachable.

## Change

- `runner-select-input.svelte`: new opt-in `constrainResults` prop — caps the runner list at `max-h-64` with `overflow-y-auto` (accessible: `role="region"` + `aria-label`), and renders a localized hint when results exceed five: "More runners are available. Scroll to view all N."
- `schedule-pipeline-form.svelte`: enables `constrainResults` and caps the dialog to `max-h-[calc(100dvh-2rem)]` with internal scroll, so the CTA stays reachable at any viewport height.
- Locale messages: `en`, `de`, `es-es`, `fr`, `it`, `pt-BR`, `da`.

## Verification

- Browser-tested with 20 runners at 720p: list capped at 256px with scrollbar, hint shown, runner selectable, CTA enabled and in viewport.
- `svelte-check` 0 errors, targeted `eslint` clean, `vitest` 177/177, production build passes.

## Notes

Language strings only; no API/backend changes.