### PR TITLE
fix(webapp): update footer links and add extras section

### DIFF
--- a/webapp/messages/da.json
+++ b/webapp/messages/da.json
@@ -1018,6 +1018,8 @@
 	"extra_eudi_atlas_description": "Omfattende EUDI-dokumentkort (organiseret efter rolle) med konformitetstestguide",
 	"extra_tl_lote_onboarding_catalogue": "TL/LoTE-onboarding/-katalog",
 	"extra_tl_lote_onboarding_catalogue_description": "Onboard EUDI-komponenter på TL/LoTE udelukkende til test og fejlfinding; ikke til produktion",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "Inspicér EUDI Token Status List-tokens og credential-statuser",
 	"Pipeline_notifications": "Pipeline-notifikationer",
 	"Pipeline_notifications_description": "Modtag en push-notifikation, når en pipelinekørsel er afsluttet.",
 	"Pipeline_notifications_enabled": "Pipeline-notifikationer aktiveret",

--- a/webapp/messages/de.json
+++ b/webapp/messages/de.json
@@ -1018,6 +1018,8 @@
 	"extra_eudi_atlas_description": "Umfassende EUDI-Dokumentenkarte (nach Rolle organisiert) mit Konformitätstest-Leitfaden",
 	"extra_tl_lote_onboarding_catalogue": "TL/LoTE-Onboarding/Katalog",
 	"extra_tl_lote_onboarding_catalogue_description": "EUDI-Komponenten auf TL/LoTE nur für Tests und Debugging onboarden; nicht für den Produktionseinsatz",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "EUDI-Token-Status-List-Tokens und Berechtigungsstatus prüfen",
 	"Pipeline_notifications": "Pipeline-Benachrichtigungen",
 	"Pipeline_notifications_description": "Erhalte eine Push-Benachrichtigung, wenn ein Pipeline-Durchlauf beendet ist.",
 	"Pipeline_notifications_enabled": "Pipeline-Benachrichtigungen aktiviert",

--- a/webapp/messages/en.json
+++ b/webapp/messages/en.json
@@ -1048,6 +1048,8 @@
 	"extra_eudi_atlas_description": "Comprehensive EUDI documents map (organized per role) with conformance test guide",
 	"extra_tl_lote_onboarding_catalogue": "TL/LoTE Onboarding/Catalogue",
 	"extra_tl_lote_onboarding_catalogue_description": "Onboard EUDI components on TL/LoTE(s) for testing and debugging only; not for production use",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "Inspect EUDI Token Status List tokens and credential statuses",
 	"Extras": "Extras",
 	"executions_CI": "CI/CD",
 	"Pipeline_notifications": "Pipeline notifications",

--- a/webapp/messages/es-es.json
+++ b/webapp/messages/es-es.json
@@ -1018,6 +1018,8 @@
 	"extra_eudi_atlas_description": "Mapa completo de documentos EUDI (organizado por rol) con guía de pruebas de conformidad",
 	"extra_tl_lote_onboarding_catalogue": "Incorporación/Catálogo TL/LoTE",
 	"extra_tl_lote_onboarding_catalogue_description": "Incorpora componentes EUDI en TL/LoTE solo para pruebas y depuración; no para producción",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "Inspecciona tokens de Token Status List de la EUDI y estados de credenciales",
 	"Pipeline_notifications": "Notificaciones de pipeline",
 	"Pipeline_notifications_description": "Recibe una notificación push cuando termina una ejecución de pipeline.",
 	"Pipeline_notifications_enabled": "Notificaciones de pipeline activadas",

--- a/webapp/messages/fr.json
+++ b/webapp/messages/fr.json
@@ -1018,6 +1018,8 @@
 	"extra_eudi_atlas_description": "Carte complète des documents EUDI (organisée par rôle) avec guide de tests de conformité",
 	"extra_tl_lote_onboarding_catalogue": "Intégration/Catalogue TL/LoTE",
 	"extra_tl_lote_onboarding_catalogue_description": "Intégrer des composants EUDI aux TL/LoTE uniquement pour les tests et le débogage ; pas pour la production",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "Inspecter les jetons de Token Status List EUDI et les statuts des credentials",
 	"Pipeline_notifications": "Notifications de pipeline",
 	"Pipeline_notifications_description": "Recevez une notification push lorsqu’une exécution de pipeline se termine.",
 	"Pipeline_notifications_enabled": "Notifications de pipeline activées",

--- a/webapp/messages/it.json
+++ b/webapp/messages/it.json
@@ -1024,6 +1024,8 @@
 	"extra_eudi_atlas_description": "Mappa completa dei documenti EUDI (organizzata per ruolo) con guida ai test di conformità",
 	"extra_tl_lote_onboarding_catalogue": "Onboarding/Catalogo TL/LoTE",
 	"extra_tl_lote_onboarding_catalogue_description": "Onboarding dei componenti EUDI su TL/LoTE solo per test e debug; non per uso in produzione",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "Ispeziona i token Token Status List EUDI e gli stati delle credenziali",
 	"Pipeline_notifications": "Notifiche delle pipeline",
 	"Pipeline_notifications_description": "Ricevi una notifica push quando termina un’esecuzione della pipeline.",
 	"Pipeline_notifications_enabled": "Notifiche delle pipeline attivate",

--- a/webapp/messages/pt-BR.json
+++ b/webapp/messages/pt-BR.json
@@ -1018,6 +1018,8 @@
 	"extra_eudi_atlas_description": "Mapa abrangente de documentos EUDI (organizado por função) com guia de testes de conformidade",
 	"extra_tl_lote_onboarding_catalogue": "Onboarding/Catálogo TL/LoTE",
 	"extra_tl_lote_onboarding_catalogue_description": "Faça o onboarding de componentes EUDI em TL/LoTE apenas para testes e depuração; não use em produção",
+	"extra_token_status_list_console": "Token Status List Console",
+	"extra_token_status_list_console_description": "Inspecione tokens de Token Status List da EUDI e status de credentials",
 	"Pipeline_notifications": "Notificações de pipeline",
 	"Pipeline_notifications_description": "Receba uma notificação push quando uma execução de pipeline terminar.",
 	"Pipeline_notifications_enabled": "Notificações de pipeline ativadas",

--- a/webapp/src/lib/layout/footer.svelte
+++ b/webapp/src/lib/layout/footer.svelte
@@ -14,6 +14,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import LanguageSelect from '@/i18n/languageSelect.svelte';
 	import { currentUser } from '@/pocketbase';
 
+	import { extras } from './topbar-links';
+
+	//	 NOTE: docs.credimi.io uses lowercase slugs (e.g. /manual/compliance-checks).
+	//	 Do not use old MkDocs-style paths like /Manual/compliance-checks.html (404).
 	const footer_data = [
 		{
 			label: m.Platform(),
@@ -21,16 +25,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				{ label: m.Overview(), url: 'https://docs.credimi.io/' },
 				{
 					label: m.Conformance_automation(),
-					url: 'https://docs.credimi.io/Manual/compliance-checks.html'
+					url: 'https://docs.credimi.io/manual/compliance-checks'
 				},
 				{ label: m.api_documentation(), url: 'https://docs.credimi.io/API/index.html' },
 				{
 					label: m.platform_architecture(),
-					url: 'https://docs.credimi.io/Software_Architecture/1_start.html'
+					url: 'https://docs.credimi.io/software-architecture'
 				},
 				{
 					label: m.deployment_options(),
-					url: 'https://docs.credimi.io/Software_Architecture/7_dev_setup.html'
+					url: 'https://docs.credimi.io/software-architecture/developer-setup'
 				}
 
 				//			,{ label: m.compliance_standards(), url: '/platform/compliance' }
@@ -60,11 +64,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				},
 				{
 					label: m.conformance_compliance_tools(),
-					url: 'https://docs.credimi.io/Software_Architecture/Workflow_YAML.html'
+					url: 'https://docs.credimi.io/software-architecture/workflow-yaml'
 				},
 				{
 					label: m.ecosystem_governance(),
-					url: 'https://docs.credimi.io/Manual/browse-hub.html'
+					url: 'https://docs.credimi.io/manual/browse-hub'
 				}
 			]
 		},
@@ -76,11 +80,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				//			{ label: m.sandbox_environment(), url: '/developers/sandbox' },
 				{
 					label: m.test_suites_runs(),
-					url: 'https://docs.credimi.io/Manual/compliance-checks.html'
+					url: 'https://docs.credimi.io/manual/compliance-checks'
 				},
 				{
 					label: m.developer_tools(),
-					url: 'https://docs.credimi.io/Software_Architecture/Workflow_YAML.html'
+					url: 'https://docs.credimi.io/software-architecture/workflow-yaml'
 				}
 				//			{ label: m.Changelog(), url: '/developers/changelog' }
 			]
@@ -105,7 +109,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			links: [
 				{ label: m.join_our_slack(), url: 'mailto:credimi@forkbomb.eu' },
 				{ label: 'GitHub', url: 'https://github.com/forkbombeu/credimi' },
-				{ label: m.events_webinars(), url: '/pages/community/events' },
+				{ label: m.events_webinars(), url: 'https://forkbomb.solutions/webinars/' },
 				{
 					label: m.conformance_community_forum(),
 					url: 'https://github.com/forkbombeu/credimi/discussions'
@@ -123,13 +127,17 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 				{ label: m.contact_us(), url: 'mailto:credimi@forkbomb.eu' },
 				{
 					label: m.legal_privacy(),
-					url: 'https://docs.credimi.io/Legal/privacy-policy.html'
+					url: 'https://docs.credimi.io/legal/privacy-policy'
 				},
 				{
 					label: m.terms_and_conditions(),
-					url: 'https://docs.credimi.io/Legal/terms-and-conditions.html'
+					url: 'https://docs.credimi.io/legal/terms-and-conditions'
 				}
 			]
+		},
+		{
+			label: m.Extras(),
+			links: extras.map(({ title, href }) => ({ label: title, url: href }))
 		}
 	];
 </script>

--- a/webapp/src/lib/layout/topbar-links.ts
+++ b/webapp/src/lib/layout/topbar-links.ts
@@ -46,5 +46,10 @@ export const extras: ExtraLink[] = [
 		href: 'https://lote.credimi.io/',
 		title: m.extra_tl_lote_onboarding_catalogue(),
 		description: m.extra_tl_lote_onboarding_catalogue_description()
+	},
+	{
+		href: 'https://tsl.credimi.io/',
+		title: m.extra_token_status_list_console(),
+		description: m.extra_token_status_list_console_description()
 	}
 ];


### PR DESCRIPTION
## What
- Fix footer docs URLs to new lowercase slugs on docs.credimi.io (old MkDocs-style paths 404)
- Point webinars link to forkbomb.solutions/webinars
- Add new **Extras** footer section reusing `extras` from topbar-links, including new Token Status List Console (tsl.credimi.io)
- Add i18n messages for the new link (da/de/en/es-es/fr/it/pt-BR)
- Prettier-format two ignored project.inlang files locally (not in diff)

## Validation
- `bun run lint`: prettier green; **2 pre-existing eslint errors** in `fcaf-report-sheet.svelte` (`svelte/prefer-svelte-reactivity`, non-reactive locals) — also fail on main, unrelated to this change
- `bun run check`: 0 errors (55 warnings, pre-existing)
- `bun run test:unit`: 33 files, 177 tests passed
- `bun run build`: ok

## Notes
- `footer.svelte` has a comment warning: docs.credimi.io uses lowercase slugs, do not use old MkDocs paths.