### PR TITLE
fix(webapp): constrain runner picker scroll in dialogs

### DIFF
--- a/webapp/src/lib/pipeline/runner/runner-select-input.svelte
+++ b/webapp/src/lib/pipeline/runner/runner-select-input.svelte
@@ -26,7 +26,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		selectedRunner?: string;
 		name?: string;
 		required?: boolean;
-		constrainResults?: boolean;
+		/** Bound-height ScrollArea for the results list (dialogs / dense forms). */
+		scrollable?: boolean;
 	};
 
 	let {
@@ -35,13 +36,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		selectedRunner,
 		name,
 		required = false,
-		constrainResults = false
+		scrollable = false
 	}: Props = $props();
 
 	const runnerCatalog = bindRunnerCatalogSearch();
 </script>
 
-{#snippet runnerResults()}
+{#if runnerCatalog.catalogLoading}
 	<RunnerSelectList
 		{presentation}
 		foundRunners={runnerCatalog.foundRunners}
@@ -49,10 +50,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		{onSelect}
 		{selectedRunner}
 	/>
-{/snippet}
-
-{#if runnerCatalog.catalogLoading}
-	{@render runnerResults()}
 {:else}
 	<div class="space-y-3" transition:fly>
 		<div class="space-y-2">
@@ -65,17 +62,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			<SearchInput search={runnerCatalog.runnerSearch} {name} />
 		</div>
 
-		{#if constrainResults}
-			<div class="max-h-64 overflow-y-auto pr-2" role="region" aria-label={m.Runners()}>
-				{@render runnerResults()}
-			</div>
-			{#if runnerCatalog.foundRunners.length > 5}
-				<p class="text-xs text-muted-foreground" aria-live="polite">
-					{m.runner_picker_scroll_hint({ count: runnerCatalog.foundRunners.length })}
-				</p>
-			{/if}
-		{:else}
-			{@render runnerResults()}
-		{/if}
+		<RunnerSelectList
+			{presentation}
+			foundRunners={runnerCatalog.foundRunners}
+			catalogLoading={runnerCatalog.catalogLoading}
+			{onSelect}
+			{selectedRunner}
+			{scrollable}
+			listContainerClass={scrollable ? 'h-[min(16rem,calc(100dvh-20rem))]' : undefined}
+		/>
 	</div>
 {/if}

--- a/webapp/src/lib/pipeline/runner/runner-select-list.svelte
+++ b/webapp/src/lib/pipeline/runner/runner-select-list.svelte
@@ -8,9 +8,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	import type { Snippet } from 'svelte';
 	import type { ClassValue } from 'svelte/elements';
 
-	import { EmptyState, WithEmptyState } from '$lib/pipeline-form/steps/_partials/index.js';
+	import { EmptyState } from '$lib/pipeline-form/steps/_partials/index.js';
 	import { fly } from 'svelte/transition';
 
+	import FadeScrollArea from '@/components/ui-custom/fade-scroll-area.svelte';
 	import Spinner from '@/components/ui-custom/spinner.svelte';
 	import T from '@/components/ui-custom/t.svelte';
 	import { m } from '@/i18n';
@@ -55,15 +56,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		{@render prepend?.()}
 
 		{#if scrollable}
-			<WithEmptyState
-				items={foundRunners}
-				emptyText={m.No_runners_found()}
-				containerClass={listContainerClass}
-			>
-				{#snippet item({ item })}
-					<RunnerSelectListItem {item} {presentation} {selectedRunner} {onSelect} />
-				{/snippet}
-			</WithEmptyState>
+			{#if foundRunners.length > 0}
+				<FadeScrollArea class={listContainerClass} refresh={foundRunners.length}>
+					{#each foundRunners as item (item.path)}
+						<RunnerSelectListItem {item} {presentation} {selectedRunner} {onSelect} />
+					{/each}
+				</FadeScrollArea>
+			{:else}
+				<EmptyState text={m.No_runners_found()} containerClass={emptyContainerClass} />
+			{/if}
 		{:else}
 			<div class={['space-y-2', listContainerClass]}>
 				{#each foundRunners as item (item.path)}

--- a/webapp/src/lib/pipeline/runner/runner-select-modal.svelte
+++ b/webapp/src/lib/pipeline/runner/runner-select-modal.svelte
@@ -62,7 +62,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	});
 </script>
 
-<Dialog bind:open {title} {description} hideTrigger>
+<Dialog
+	bind:open
+	{title}
+	{description}
+	hideTrigger
+	contentClass="max-h-[calc(100dvh-2rem)] overflow-hidden"
+>
 	{#snippet content()}
 		<!-- {#if currentRunner}
 			<Alert variant="info" class="bg-blue-50">
@@ -76,6 +82,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 			presentation="run"
 			onSelect={handleSelect}
 			selectedRunner={currentRunnerPath}
+			scrollable
 		/>
 	{/snippet}
 </Dialog>

--- a/webapp/src/modules/components/ui-custom/fade-scroll-area.svelte
+++ b/webapp/src/modules/components/ui-custom/fade-scroll-area.svelte
@@ -1,0 +1,92 @@
+<!--
+SPDX-FileCopyrightText: 2026 Forkbomb BV
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script lang="ts">
+	import type { ClassValue } from 'svelte/elements';
+
+	import { tick, type Snippet } from 'svelte';
+
+	import { ScrollArea } from '@/components/ui/scroll-area';
+	import { cn } from '@/components/ui/utils.js';
+
+	type Props = {
+		class?: ClassValue;
+		contentClass?: ClassValue;
+		/** Re-measure fades when this value changes (e.g. filtered list length). */
+		refresh?: unknown;
+		children?: Snippet;
+	};
+
+	let { class: className, contentClass, refresh, children }: Props = $props();
+
+	let viewportRef = $state<HTMLElement | null>(null);
+	let canScrollUp = $state(false);
+	let canScrollDown = $state(false);
+
+	function updateFades() {
+		const viewport = viewportRef;
+		if (!viewport) {
+			canScrollUp = false;
+			canScrollDown = false;
+			return;
+		}
+
+		const { scrollTop, scrollHeight, clientHeight } = viewport;
+		canScrollUp = scrollTop > 1;
+		canScrollDown = scrollTop + clientHeight < scrollHeight - 1;
+	}
+
+	$effect(() => {
+		const viewport = viewportRef;
+		if (!viewport) return;
+
+		updateFades();
+		viewport.addEventListener('scroll', updateFades, { passive: true });
+
+		const observer = new ResizeObserver(() => updateFades());
+		observer.observe(viewport);
+		for (const child of viewport.children) {
+			observer.observe(child);
+		}
+
+		return () => {
+			viewport.removeEventListener('scroll', updateFades);
+			observer.disconnect();
+		};
+	});
+
+	$effect(() => {
+		void refresh;
+		void tick().then(updateFades);
+	});
+</script>
+
+<div class={cn('relative min-h-0 overflow-hidden', className)}>
+	<ScrollArea
+		bind:viewportRef
+		type="always"
+		class="size-full overflow-hidden"
+		scrollbarYClasses="z-10 rounded-full bg-muted/80 [&_[data-slot=scroll-area-thumb]]:bg-muted-foreground/35"
+	>
+		<div class={cn('space-y-2 p-1 pr-5', contentClass)}>
+			{@render children?.()}
+		</div>
+	</ScrollArea>
+
+	{#if canScrollUp}
+		<div
+			class="pointer-events-none absolute start-0 end-3 top-0 z-[5] h-6 bg-gradient-to-b from-background to-transparent"
+			aria-hidden="true"
+		></div>
+	{/if}
+
+	{#if canScrollDown}
+		<div
+			class="pointer-events-none absolute start-0 end-3 bottom-0 z-[5] h-6 bg-gradient-to-t from-background to-transparent"
+			aria-hidden="true"
+		></div>
+	{/if}
+</div>

--- a/webapp/src/routes/my/pipelines/_partials/schedule-pipeline-form.svelte
+++ b/webapp/src/routes/my/pipelines/_partials/schedule-pipeline-form.svelte
@@ -132,7 +132,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 					onSelect={onRunnerSelect}
 					selectedRunner={($formData as { global_runner_id?: string }).global_runner_id}
 					required
-					constrainResults
+					scrollable
 				/>
 			{/if}
 


### PR DESCRIPTION
## Summary
- Cap runner selection dialogs/lists to the viewport and scroll the runner list instead of growing the dialog
- Replace `constrainResults` / raw `overflow-y-auto` with a new `FadeScrollArea` wrapper (always-visible track, content padding, top/bottom fades) without changing shadcn `ScrollArea`
- Apply the same scrollable path to the schedule pipeline runner picker and the run-now runner modal

## Test plan
- [ ] Open **Schedule pipeline** with many runners: Schedule button stays visible; list scrolls; hover rings are not clipped; light scrollbar track is always visible
- [ ] Open **Run now** runner selection modal with many runners: dialog stays within the viewport; list scrolls with fades when more content exists
- [ ] Filter runners via search: fades update; empty state still works
- [ ] Confirm wallet-action runner step (`scrollable` list) still renders without layout breakage

Made with [Cursor](https://cursor.com)