### PR TITLE
fix(workflows): bypass proxy for scheduled callbacks

### DIFF
--- a/pkg/workflowengine/workflows/scheduled_pipeline_enqueue.go
+++ b/pkg/workflowengine/workflows/scheduled_pipeline_enqueue.go
@@ -93,6 +93,7 @@ func (w *ScheduledPipelineEnqueueWorkflow) ExecuteWorkflow(
 		config["namespace"] = ownerNamespace
 	}
 	appURL, _ := config["app_url"].(string)
+	internalAppURL := workflowengine.InternalAppURLFromConfig(config)
 
 	if pipelineIdentifier == "" {
 		return workflowengine.WorkflowResult{}, workflowengine.NewMissingOrInvalidPayloadError(
@@ -132,7 +133,7 @@ func (w *ScheduledPipelineEnqueueWorkflow) ExecuteWorkflow(
 		Payload: activities.HTTPActivityPayload{
 			Method: http.MethodPost,
 			URL: utils.JoinURL(
-				appURL,
+				internalAppURL,
 				"api", "canonify", "identifier", "validate",
 			),
 			Headers: map[string]string{
@@ -275,7 +276,7 @@ func (w *ScheduledPipelineEnqueueWorkflow) ExecuteWorkflow(
 	}
 	if err := validateScheduledPipelineRunnerAccess(
 		ctx,
-		appURL,
+		internalAppURL,
 		ownerNamespace,
 		deviceIDs,
 		input.RunMetadata,

--- a/pkg/workflowengine/workflows/scheduled_pipeline_enqueue_test.go
+++ b/pkg/workflowengine/workflows/scheduled_pipeline_enqueue_test.go
@@ -42,7 +42,8 @@ steps:
 			MaxPipelinesInQueue: 3,
 		},
 		Config: map[string]any{
-			"app_url": "https://example.test",
+			"app_url":          "https://example.test",
+			"internal_app_url": "http://credimi:8090",
 		},
 	}
 
@@ -59,6 +60,8 @@ steps:
 	})
 
 	var capturedPayload activities.EnqueuePipelineRunTicketActivityInput
+	var capturedHTTPURL string
+	var capturedInternalHTTPURL string
 	env.RegisterActivityWithOptions(
 		func(_ context.Context, input workflowengine.ActivityInput) (workflowengine.ActivityResult, error) {
 			payload, err := workflowengine.DecodePayload[activities.EnqueuePipelineRunTicketActivityInput](
@@ -72,6 +75,15 @@ steps:
 	)
 
 	env.OnActivity(httpAct.Name(), mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input, ok := args.Get(1).(workflowengine.ActivityInput)
+			require.True(t, ok)
+			payload, err := workflowengine.DecodePayload[activities.HTTPActivityPayload](
+				input.Payload,
+			)
+			require.NoError(t, err)
+			capturedHTTPURL = payload.URL
+		}).
 		Return(workflowengine.ActivityResult{
 			Output: map[string]any{
 				"body": map[string]any{
@@ -83,6 +95,15 @@ steps:
 			},
 		}, nil)
 	env.OnActivity(internalHTTPAct.Name(), mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input, ok := args.Get(1).(workflowengine.ActivityInput)
+			require.True(t, ok)
+			payload, err := workflowengine.DecodePayload[activities.InternalHTTPActivityPayload](
+				input.Payload,
+			)
+			require.NoError(t, err)
+			capturedInternalHTTPURL = payload.URL
+		}).
 		Return(workflowengine.ActivityResult{
 			Output: map[string]any{
 				"body": map[string]any{"valid": true},
@@ -113,6 +134,17 @@ steps:
 	config := capturedPayload.PipelineConfig
 	require.Equal(t, "org-1", config["namespace"])
 	require.Equal(t, "https://example.test", config["app_url"])
+	require.Equal(t, "http://credimi:8090", config["internal_app_url"])
+	require.Equal(
+		t,
+		"http://credimi:8090/api/canonify/identifier/validate",
+		capturedHTTPURL,
+	)
+	require.Equal(
+		t,
+		"http://credimi:8090/api/mobile-runner/validate-access",
+		capturedInternalHTTPURL,
+	)
 
 	require.Equal(t, "pipeline-run", capturedPayload.Memo["test"])
 	require.Equal(


### PR DESCRIPTION
## Summary

- route scheduled pipeline canonify validation through `internal_app_url`
- route scheduled runner-access validation through `internal_app_url`
- preserve public `app_url` for user-facing links
- add regression assertions for both callback URLs

This prevents Temporal callbacks from reaching the Cloudflare challenge page when the public Credimi URL is proxied.

## Validation

- `make fmt`
- `make lint`
- `make test`
- focused scheduled enqueue workflow test

## Deployment note

Set `CREDIMI_INTERNAL_APP_URL` to an origin-reachable URL for Temporal workers. Existing schedules created before this value was configured should be recreated or resaved so their persisted workflow config includes `internal_app_url`.
