### PR TITLE
fix(build): bump builder image and mise pin to go 1.27

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -5,7 +5,7 @@
 min_version = '2025.1.8'
 
 [tools]
-go = "1.26.6"
+go = "1.27.0"
 bun = "latest"
 node = "24.13.0"
 "aqua:dyne/slangroom-exec" = "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 WORKDIR /src
 
 RUN apk update && apk add --no-cache git


### PR DESCRIPTION
## Problem

PR #1366 (merged to `main` as c113f9c9) bumped `go.mod` to require Go >= 1.27 and fixed CI's `setup-go` version, but two toolchain entrypoints were left on Go 1.26. The first production deployment of `main` failed at the `go mod download` build step:

```
go: go.mod requires go >= 1.27 (running go 1.26.8; GOTOOLCHAIN=local)
```

## Change

- `Dockerfile`: builder stage `golang:1.26-alpine` -> `golang:1.27-alpine` (verified the tag resolves to go1.27.1).
- `.mise.toml`: `go = "1.26.6"` -> `go = "1.27.0"` (matches CI's setup-go 1.27.0 and the local toolchain).

## Verification

- `golang:1.27-alpine` tag exists and ships go1.27.1 (>= go.mod requirement).
- Local toolchain is go1.27.0; full unit suite and `make lint` are green on this toolchain (run during #1366).
